### PR TITLE
SCRUM-133: Search products by name or description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,21 @@ npm run format:check  # Prettier validation (used in CI)
 npm test              # Jest (single run)
 ```
 
+### Before committing
+
+Run these in both packages before every commit — CI enforces all four:
+
+```bash
+# Frontend
+cd frontend && npm run lint && npm run format:check
+
+# Backend
+cd backend && npm run lint && npm run format:check
+
+# Auto-fix formatting (then re-check)
+npm run format
+```
+
 ### Running a single test
 
 ```bash
@@ -52,7 +67,10 @@ cd backend && npx jest --testNamePattern "returns 201"
 docker compose up --build   # First run, or after package.json changes
 docker compose up           # Subsequent runs
 docker compose down         # Stop and remove containers
+docker compose down -v      # Stop and remove containers AND all volumes (see warning below)
 ```
+
+> **Warning — `down -v`:** Removes **all** volumes, including the named `postgres_data` volume. All database data (users, products, orders) will be lost. Only use this to fix stale anonymous `node_modules` volumes when `nodemon` or other packages are not found inside the container despite being in `package.json`. After running, re-seed the database.
 
 Services: frontend → <http://localhost:5173>, backend → <http://localhost:3000>, PostgreSQL → localhost:5432
 
@@ -139,7 +157,7 @@ docker compose exec backend node scripts/seed-products.js
 Route files live in `backend/routes/`:
 
 - `auth.js` — `POST /api/auth/register`, `POST /api/auth/login`, and password reset endpoints
-- `products.js` — public `GET /api/products` (no auth); supports `?category=` and `?limit=` query params; results ordered by `created_at DESC`; returns `available_stock` (stock minus active reservations)
+- `products.js` — public (no auth); `GET /api/products` supports `?category=` and `?limit=`; `GET /api/products/search` supports `?q=` (case-insensitive partial match on name + description, ordered by name ASC; single-char queries return empty; empty q returns all)
 - `cart.js` — authenticated cart CRUD at `/api/cart`; `GET` returns items, `POST` upserts (increments if already present), `PUT /:productId` sets exact quantity, `DELETE /:productId` removes one item, `DELETE /` clears the cart
 - `checkout.js` — authenticated checkout flow at `/api/checkout`; `POST /reserve` soft-locks stock for 10 min, `DELETE /reserve` releases the lock, `POST /confirm` hard-decrements stock and creates the order
 - `admin.js` — user CRUD at `/api/admin/users` and `GET /api/admin/me`
@@ -182,6 +200,7 @@ Pages are colocated with their CSS under `src/pages/<section>/`. Admin pages liv
 **Product data is fetched from the API, not hardcoded:**
 - `CategoryPage` — fetches `GET /api/products?category={category.title}` on mount; shows a loading state while the request is in flight
 - `HomePage` new releases — fetches `GET /api/products?limit=8` on mount; the 8 most recently added products are shown as new releases (insertion order drives this — no explicit "featured" flag exists)
+- `SearchPage` (`src/pages/search/SearchPage.jsx`) — public route at `/search?q=`; fetches `GET /api/products/search?q=`; accessible to guests; Navbar search bar navigates here on submit
 
 ### Database schema
 

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -4,12 +4,23 @@ const pool = require('../db')
 const router = express.Router()
 
 // GET /api/products/search — search products by name or description, ?q= ?limit=
+// Empty or missing q returns all products sorted alphabetically.
 router.get('/search', async (req, res) => {
   const q = (req.query.q || '').trim()
-  if (!q) return res.json({ products: [] })
-
   const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 50))
-  const term = `%${q}%`
+
+  // Single-character queries match too broadly — reject them early
+  if (q.length === 1) return res.json({ products: [] })
+
+  let whereClause = ''
+  let params = []
+
+  if (q) {
+    whereClause = 'WHERE (p.name ILIKE $1 OR p.description ILIKE $1)'
+    params = [`%${q}%`, limit]
+  } else {
+    params = [limit]
+  }
 
   const result = await pool.query(
     `SELECT p.id, p.name, p.description, p.price, p.stock, p.category, p.image_url, p.created_at,
@@ -24,11 +35,11 @@ router.get('/search', async (req, res) => {
      LEFT JOIN product_discounts pd ON pd.product_id = p.id
        AND pd.start_at <= NOW()
        AND (pd.end_at IS NULL OR pd.end_at > NOW())
-     WHERE (p.name ILIKE $1 OR p.description ILIKE $1)
+     ${whereClause}
      GROUP BY p.id, pd.discount_percent
-     ORDER BY p.created_at DESC
-     LIMIT $2`,
-    [term, limit]
+     ORDER BY p.name ASC
+     LIMIT $${params.length}`,
+    params
   )
 
   res.json({ products: result.rows })

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -12,15 +12,8 @@ router.get('/search', async (req, res) => {
   // Single-character queries match too broadly — reject them early
   if (q.length === 1) return res.json({ products: [] })
 
-  let whereClause = ''
-  let params = []
-
-  if (q) {
-    whereClause = 'WHERE (p.name ILIKE $1 OR p.description ILIKE $1)'
-    params = [`%${q}%`, limit]
-  } else {
-    params = [limit]
-  }
+  const whereClause = q ? 'WHERE (p.name ILIKE $1 OR p.description ILIKE $1)' : ''
+  const params = q ? [`%${q}%`, limit] : [limit]
 
   const result = await pool.query(
     `SELECT p.id, p.name, p.description, p.price, p.stock, p.category, p.image_url, p.created_at,

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -7,13 +7,22 @@ const router = express.Router()
 // Empty or missing q returns all products sorted alphabetically.
 router.get('/search', async (req, res) => {
   const q = (req.query.q || '').trim()
-  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 50))
 
   // Single-character queries match too broadly — reject them early
   if (q.length === 1) return res.json({ products: [] })
 
+  // For keyword searches: default limit 50, capped at 100.
+  // For "show all" (empty q): no default limit; explicit ?limit= is still respected.
+  const explicitLimit =
+    req.query.limit !== undefined
+      ? Math.min(100, Math.max(1, parseInt(req.query.limit) || 1))
+      : null
+  const limit = explicitLimit ?? (q ? 50 : null)
+
   const whereClause = q ? 'WHERE (p.name ILIKE $1 OR p.description ILIKE $1)' : ''
-  const params = q ? [`%${q}%`, limit] : [limit]
+  const params = q ? [`%${q}%`] : []
+  if (limit !== null) params.push(limit)
+  const limitClause = limit !== null ? `LIMIT $${params.length}` : ''
 
   const result = await pool.query(
     `SELECT p.id, p.name, p.description, p.price, p.stock, p.category, p.image_url, p.created_at,
@@ -31,7 +40,7 @@ router.get('/search', async (req, res) => {
      ${whereClause}
      GROUP BY p.id, pd.discount_percent
      ORDER BY p.name ASC
-     LIMIT $${params.length}`,
+     ${limitClause}`,
     params
   )
 

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -3,6 +3,37 @@ const pool = require('../db')
 
 const router = express.Router()
 
+// GET /api/products/search — search products by name or description, ?q= ?limit=
+router.get('/search', async (req, res) => {
+  const q = (req.query.q || '').trim()
+  if (!q) return res.json({ products: [] })
+
+  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 50))
+  const term = `%${q}%`
+
+  const result = await pool.query(
+    `SELECT p.id, p.name, p.description, p.price, p.stock, p.category, p.image_url, p.created_at,
+            GREATEST(0, p.stock - COALESCE(SUM(sr.quantity), 0)) AS available_stock,
+            pd.discount_percent,
+            CASE WHEN pd.discount_percent IS NOT NULL
+                 THEN ROUND(p.price * (1 - pd.discount_percent / 100.0), 2)
+                 ELSE NULL
+            END AS discounted_price
+     FROM products p
+     LEFT JOIN stock_reservations sr ON sr.product_id = p.id AND sr.expires_at > NOW()
+     LEFT JOIN product_discounts pd ON pd.product_id = p.id
+       AND pd.start_at <= NOW()
+       AND (pd.end_at IS NULL OR pd.end_at > NOW())
+     WHERE (p.name ILIKE $1 OR p.description ILIKE $1)
+     GROUP BY p.id, pd.discount_percent
+     ORDER BY p.created_at DESC
+     LIMIT $2`,
+    [term, limit]
+  )
+
+  res.json({ products: result.rows })
+})
+
 // GET /api/products — list products, optional ?category= and ?limit=
 router.get('/', async (req, res) => {
   const category = (req.query.category || '').trim()

--- a/backend/test/products-search.test.js
+++ b/backend/test/products-search.test.js
@@ -50,16 +50,32 @@ describe('GET /api/products/search', () => {
     expect(params[0]).toBe('%powerful%')
   })
 
-  it('returns empty array and skips DB call when q is empty', async () => {
+  it('returns all products when q is empty', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [mockProduct()] })
+
     const res = await request(app).get('/api/products/search?q=')
 
     expect(res.status).toBe(200)
-    expect(res.body).toEqual({ products: [] })
-    expect(pool.query).not.toHaveBeenCalled()
+    expect(res.body.products).toHaveLength(1)
+    expect(pool.query).toHaveBeenCalled()
+
+    // No ILIKE clause when q is empty
+    const [sql] = pool.query.mock.calls[0]
+    expect(sql).not.toMatch(/ILIKE/)
   })
 
-  it('returns empty array and skips DB call when q is whitespace', async () => {
+  it('returns all products when q is whitespace', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [mockProduct()] })
+
     const res = await request(app).get('/api/products/search?q=   ')
+
+    expect(res.status).toBe(200)
+    expect(res.body.products).toHaveLength(1)
+    expect(pool.query).toHaveBeenCalled()
+  })
+
+  it('returns empty array without hitting DB for single-character query', async () => {
+    const res = await request(app).get('/api/products/search?q=a')
 
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ products: [] })

--- a/backend/test/products-search.test.js
+++ b/backend/test/products-search.test.js
@@ -59,9 +59,20 @@ describe('GET /api/products/search', () => {
     expect(res.body.products).toHaveLength(1)
     expect(pool.query).toHaveBeenCalled()
 
-    // No ILIKE clause when q is empty
+    // No ILIKE clause and no LIMIT when q is empty and no explicit limit given
     const [sql] = pool.query.mock.calls[0]
     expect(sql).not.toMatch(/ILIKE/)
+    expect(sql).not.toMatch(/LIMIT/)
+  })
+
+  it('respects explicit limit when q is empty', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] })
+
+    await request(app).get('/api/products/search?q=&limit=10')
+
+    const [sql, params] = pool.query.mock.calls[0]
+    expect(sql).toMatch(/LIMIT/)
+    expect(params[params.length - 1]).toBe(10)
   })
 
   it('returns all products when q is whitespace', async () => {

--- a/backend/test/products-search.test.js
+++ b/backend/test/products-search.test.js
@@ -1,0 +1,118 @@
+jest.mock('../db', () => ({ query: jest.fn() }))
+
+const pool = require('../db')
+process.env.JWT_SECRET = 'test-secret'
+const app = require('../app')
+const request = require('supertest')
+
+describe('GET /api/products/search', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  const mockProduct = (overrides = {}) => ({
+    id: 1,
+    name: 'Laptop Pro',
+    description: 'A powerful laptop for professionals.',
+    price: '1299.99',
+    stock: 10,
+    category: 'Computers',
+    image_url: null,
+    created_at: new Date().toISOString(),
+    available_stock: 10,
+    discount_percent: null,
+    discounted_price: null,
+    ...overrides,
+  })
+
+  it('returns products matching the name (partial, case-insensitive)', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [mockProduct()] })
+
+    const res = await request(app).get('/api/products/search?q=lap')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('products')
+    expect(res.body.products).toHaveLength(1)
+    expect(res.body.products[0].name).toBe('Laptop Pro')
+
+    const [sql, params] = pool.query.mock.calls[0]
+    expect(sql).toMatch(/ILIKE/i)
+    expect(params[0]).toBe('%lap%')
+  })
+
+  it('returns products matching the description', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [mockProduct()] })
+
+    const res = await request(app).get('/api/products/search?q=powerful')
+
+    expect(res.status).toBe(200)
+    expect(res.body.products).toHaveLength(1)
+
+    const [, params] = pool.query.mock.calls[0]
+    expect(params[0]).toBe('%powerful%')
+  })
+
+  it('returns empty array and skips DB call when q is empty', async () => {
+    const res = await request(app).get('/api/products/search?q=')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ products: [] })
+    expect(pool.query).not.toHaveBeenCalled()
+  })
+
+  it('returns empty array and skips DB call when q is whitespace', async () => {
+    const res = await request(app).get('/api/products/search?q=   ')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ products: [] })
+    expect(pool.query).not.toHaveBeenCalled()
+  })
+
+  it('returns empty array when no products match', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] })
+
+    const res = await request(app).get('/api/products/search?q=zzznomatch')
+
+    expect(res.status).toBe(200)
+    expect(res.body.products).toHaveLength(0)
+  })
+
+  it('includes out-of-stock products in results', async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [mockProduct({ stock: 0, available_stock: 0 })],
+    })
+
+    const res = await request(app).get('/api/products/search?q=laptop')
+
+    expect(res.status).toBe(200)
+    expect(res.body.products[0].available_stock).toBe(0)
+  })
+
+  it('returns discount fields when a discount is active', async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [mockProduct({ discount_percent: 20, discounted_price: '1039.99' })],
+    })
+
+    const res = await request(app).get('/api/products/search?q=laptop')
+
+    expect(res.status).toBe(200)
+    expect(res.body.products[0].discount_percent).toBe(20)
+    expect(res.body.products[0].discounted_price).toBe('1039.99')
+  })
+
+  it('respects the limit query parameter', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] })
+
+    await request(app).get('/api/products/search?q=laptop&limit=5')
+
+    const [, params] = pool.query.mock.calls[0]
+    expect(params[1]).toBe(5)
+  })
+
+  it('caps limit at 100', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] })
+
+    await request(app).get('/api/products/search?q=laptop&limit=500')
+
+    const [, params] = pool.query.mock.calls[0]
+    expect(params[1]).toBe(100)
+  })
+})

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import {
   useNavigate,
   useLocation,
   useNavigationType,
+  useSearchParams,
 } from 'react-router-dom'
 import AdminLoginPage from './pages/admin/AdminLoginPage'
 import SalesManagerLoginPage from './pages/sales-manager/SalesManagerLoginPage'
@@ -20,6 +21,7 @@ import CartPage from './pages/cart/CartPage'
 import CheckoutPage from './pages/checkout/CheckoutPage'
 import WishlistPage from './pages/wishlist/WishlistPage'
 import CategoryPage from './pages/category/CategoryPage'
+import SearchPage from './pages/search/SearchPage'
 import AccountSettingsPage from './pages/account/AccountSettingsPage'
 import OrdersPage from './pages/orders/OrdersPage'
 import HelpPage from './pages/help/HelpPage'
@@ -75,6 +77,32 @@ function CategoryRoute({
   return (
     <CategoryPage
       category={state.category}
+      onBack={() => navigate(-1)}
+      onAddToCart={onAddToCart}
+      onRemoveFromCart={onRemoveFromCart}
+      onAddToWishlist={onAddToWishlist}
+      onRemoveFromWishlist={onRemoveFromWishlist}
+      cartItems={cartItems}
+      wishlistItems={wishlistItems}
+    />
+  )
+}
+
+function SearchRoute({
+  onAddToCart,
+  onRemoveFromCart,
+  onAddToWishlist,
+  onRemoveFromWishlist,
+  cartItems,
+  wishlistItems,
+}) {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const q = searchParams.get('q') || ''
+
+  return (
+    <SearchPage
+      searchQuery={q}
       onBack={() => navigate(-1)}
       onAddToCart={onAddToCart}
       onRemoveFromCart={onRemoveFromCart}
@@ -463,6 +491,19 @@ function App() {
           path="/category"
           element={
             <CategoryRoute
+              onAddToCart={addToCart}
+              onRemoveFromCart={removeFromCart}
+              onAddToWishlist={addToWishlist}
+              onRemoveFromWishlist={removeFromWishlist}
+              cartItems={cart}
+              wishlistItems={wishlist}
+            />
+          }
+        />
+        <Route
+          path="/search"
+          element={
+            <SearchRoute
               onAddToCart={addToCart}
               onRemoveFromCart={removeFromCart}
               onAddToWishlist={addToWishlist}

--- a/frontend/src/pages/home/components/Navbar.jsx
+++ b/frontend/src/pages/home/components/Navbar.jsx
@@ -34,7 +34,7 @@ export default function Navbar({
     e.preventDefault()
     const q = searchQuery.trim()
     // Allow empty (shows all products) and 2+ chars; block single-char noise
-    if (q.length !== 1) navigate('/search?q=' + encodeURIComponent(q))
+    if (q.length !== 1) navigate(q ? '/search?q=' + encodeURIComponent(q) : '/search')
   }
 
   useEffect(() => {

--- a/frontend/src/pages/home/components/Navbar.jsx
+++ b/frontend/src/pages/home/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   CartIcon,
   WishlistIcon,
@@ -27,6 +28,14 @@ export default function Navbar({
   const [avatarOpen, setAvatarOpen] = useState(false)
   const avatarRef = useRef(null)
   const { theme, toggleTheme } = useTheme()
+  const navigate = useNavigate()
+
+  function handleSearchSubmit(e) {
+    e.preventDefault()
+    const q = searchQuery.trim()
+    // Allow empty (shows all products) and 2+ chars; block single-char noise
+    if (q.length !== 1) navigate('/search?q=' + encodeURIComponent(q))
+  }
 
   useEffect(() => {
     function handleClickOutside(e) {
@@ -47,10 +56,17 @@ export default function Navbar({
         </div>
 
         {/* Search bar */}
-        <div className="flex h-10 max-w-[480px] flex-1 items-center gap-2 rounded-[10px] border border-[var(--border)] bg-[var(--card-bg)] px-[14px] backdrop-blur-xl transition-[border-color,background] duration-200 focus-within:border-purple-400/50 focus-within:bg-[var(--card-bg)]">
-          <span className="flex items-center text-[var(--text)]">
+        <form
+          onSubmit={handleSearchSubmit}
+          className="flex h-10 max-w-[480px] flex-1 items-center gap-2 rounded-[10px] border border-[var(--border)] bg-[var(--card-bg)] px-[14px] backdrop-blur-xl transition-[border-color,background] duration-200 focus-within:border-purple-400/50 focus-within:bg-[var(--card-bg)]"
+        >
+          <button
+            type="submit"
+            aria-label="Search"
+            className="flex items-center border-none bg-transparent p-0 text-[var(--text)] hover:text-purple-400"
+          >
             <SearchIcon />
-          </span>
+          </button>
           <input
             type="text"
             placeholder="Search for clothes, brands…"
@@ -58,7 +74,13 @@ export default function Navbar({
             onChange={(e) => setSearchQuery(e.target.value)}
             className="flex-1 border-none bg-transparent text-sm text-[var(--text-h)] outline-none placeholder:text-[var(--text)]/40"
           />
-        </div>
+          <button
+            type="submit"
+            className="shrink-0 rounded-md border-none bg-purple-400/15 px-2.5 py-1 text-[12px] font-semibold text-purple-400 transition-colors hover:bg-purple-400/28"
+          >
+            Search
+          </button>
+        </form>
 
         {/* Actions */}
         <nav className="ml-auto flex items-center gap-2">

--- a/frontend/src/pages/search/SearchPage.jsx
+++ b/frontend/src/pages/search/SearchPage.jsx
@@ -87,13 +87,18 @@ export default function SearchPage({
   const [products, setProducts] = useState([])
   const [loadedQuery, setLoadedQuery] = useState(null)
   const [inputValue, setInputValue] = useState(searchQuery)
+  const [error, setError] = useState(false)
   const navigate = useNavigate()
   const loading = loadedQuery !== searchQuery
 
   useEffect(() => {
     let cancelled = false
+    setError(false)
     fetch(`${API_BASE}/api/products/search?q=${encodeURIComponent(searchQuery)}`)
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error('Server error')
+        return r.json()
+      })
       .then((data) => {
         if (!cancelled) {
           setProducts(data.products ?? [])
@@ -103,6 +108,7 @@ export default function SearchPage({
       .catch(() => {
         if (!cancelled) {
           setProducts([])
+          setError(true)
           setLoadedQuery(searchQuery)
         }
       })
@@ -111,10 +117,15 @@ export default function SearchPage({
     }
   }, [searchQuery])
 
+  useEffect(() => {
+    setInputValue(searchQuery)
+  }, [searchQuery])
+
   function handleSearchSubmit(e) {
     e.preventDefault()
     const q = inputValue.trim()
-    if (q.length !== 1) navigate('/search?q=' + encodeURIComponent(q), { replace: true })
+    if (q.length !== 1)
+      navigate(q ? '/search?q=' + encodeURIComponent(q) : '/search', { replace: true })
   }
 
   const cartIds = new Set(cartItems.map((i) => i.id))
@@ -171,11 +182,13 @@ export default function SearchPage({
           </h1>
           {!loading && (
             <p className="m-0 text-[15px] text-[var(--text)]">
-              {products.length === 0
-                ? searchQuery
-                  ? `No products found for "${searchQuery}"`
-                  : 'No products available.'
-                : `${products.length} product${products.length !== 1 ? 's' : ''} found`}
+              {error
+                ? 'Failed to load products. Please try again.'
+                : products.length === 0
+                  ? searchQuery
+                    ? `No products found for "${searchQuery}"`
+                    : 'No products available.'
+                  : `${products.length} product${products.length !== 1 ? 's' : ''} found`}
             </p>
           )}
         </div>

--- a/frontend/src/pages/search/SearchPage.jsx
+++ b/frontend/src/pages/search/SearchPage.jsx
@@ -1,0 +1,280 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import API_BASE from '../../api'
+
+function BackIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="19" y1="12" x2="5" y2="12" />
+      <polyline points="12 19 5 12 12 5" />
+    </svg>
+  )
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  )
+}
+
+function CartIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <path d="M16 10a4 4 0 01-8 0" />
+    </svg>
+  )
+}
+
+function HeartIcon({ filled }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z" />
+    </svg>
+  )
+}
+
+export default function SearchPage({
+  searchQuery,
+  onBack,
+  onAddToCart,
+  onRemoveFromCart,
+  onAddToWishlist,
+  onRemoveFromWishlist,
+  cartItems = [],
+  wishlistItems = [],
+}) {
+  const [products, setProducts] = useState([])
+  const [loadedQuery, setLoadedQuery] = useState(null)
+  const [inputValue, setInputValue] = useState(searchQuery)
+  const navigate = useNavigate()
+  const loading = loadedQuery !== searchQuery
+
+  useEffect(() => {
+    setInputValue(searchQuery)
+
+    let cancelled = false
+    fetch(`${API_BASE}/api/products/search?q=${encodeURIComponent(searchQuery)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled) {
+          setProducts(data.products ?? [])
+          setLoadedQuery(searchQuery)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setProducts([])
+          setLoadedQuery(searchQuery)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [searchQuery])
+
+  function handleSearchSubmit(e) {
+    e.preventDefault()
+    const q = inputValue.trim()
+    if (q.length !== 1) navigate('/search?q=' + encodeURIComponent(q), { replace: true })
+  }
+
+  const cartIds = new Set(cartItems.map((i) => i.id))
+  const wishlistIds = new Set(wishlistItems.map((i) => i.id))
+
+  return (
+    <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
+      <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
+        <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
+          <button
+            className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
+            onClick={onBack}
+          >
+            <BackIcon /> Back
+          </button>
+          <form
+            onSubmit={handleSearchSubmit}
+            className="flex h-9 flex-1 items-center gap-2 rounded-[10px] border border-[var(--border)] bg-[var(--card-bg)] px-3 backdrop-blur-xl transition-[border-color] focus-within:border-purple-400/50"
+          >
+            <button
+              type="submit"
+              aria-label="Search"
+              className="flex items-center border-none bg-transparent p-0 text-[var(--text)] hover:text-purple-400"
+            >
+              <SearchIcon />
+            </button>
+            <input
+              type="text"
+              placeholder="Search products…"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              className="flex-1 border-none bg-transparent text-sm text-[var(--text-h)] outline-none placeholder:text-[var(--text)]/40"
+            />
+            <button
+              type="submit"
+              className="shrink-0 rounded-md border-none bg-purple-400/15 px-2.5 py-1 text-[12px] font-semibold text-purple-400 transition-colors hover:bg-purple-400/28"
+            >
+              Search
+            </button>
+          </form>
+          <span className="ml-auto shrink-0 text-[22px] font-bold tracking-[4px] text-[var(--text-h)]">
+            FIER
+          </span>
+        </div>
+      </header>
+
+      <main className="mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
+        <div className="mb-10">
+          <p className="m-0 mb-2.5 text-[11px] font-bold tracking-[5px] text-purple-400 uppercase">
+            Search
+          </p>
+          <h1 className="m-0 mb-2 text-[36px] font-extrabold tracking-[-1px] text-[var(--text-h)] max-[720px]:text-[28px]">
+            {searchQuery ? `Results for "${searchQuery}"` : 'All Products'}
+          </h1>
+          {!loading && (
+            <p className="m-0 text-[15px] text-[var(--text)]">
+              {products.length === 0
+                ? searchQuery
+                  ? `No products found for "${searchQuery}"`
+                  : 'No products available.'
+                : `${products.length} product${products.length !== 1 ? 's' : ''} found`}
+            </p>
+          )}
+        </div>
+
+        {loading && <p className="text-[var(--text)] opacity-60">Loading products…</p>}
+
+        <div className="grid [grid-template-columns:repeat(4,1fr)] gap-5 max-[1024px]:[grid-template-columns:repeat(3,1fr)] max-[720px]:[grid-template-columns:repeat(2,1fr)] max-[720px]:gap-3.5 max-[420px]:[grid-template-columns:1fr]">
+          {products.map((product) => {
+            const inCart = cartIds.has(product.id)
+            const inWishlist = wishlistIds.has(product.id)
+            const availableStock = parseInt(product.available_stock ?? product.stock ?? 0)
+            const outOfStock = availableStock === 0
+            return (
+              <div
+                key={product.id}
+                className="flex flex-col overflow-hidden rounded-2xl border border-[var(--glass-border)] bg-[var(--card-bg)] shadow-[var(--shadow)] backdrop-blur-xl transition-[box-shadow,transform,border-color] duration-250 hover:-translate-y-1 hover:border-purple-400/40 hover:shadow-[0_8px_24px_rgba(0,0,0,0.15),0_0_0_1px_rgba(192,132,252,0.35),inset_0_1px_0_rgba(255,255,255,0.18)]"
+              >
+                <div className="flex aspect-[3/4] w-full items-center justify-center border-b border-[var(--glass-border)] bg-purple-400/12">
+                  <span className="text-[64px] font-bold text-purple-400 opacity-35 select-none">
+                    {product.name[0]}
+                  </span>
+                </div>
+                <div className="flex flex-1 flex-col gap-1 px-4 pt-3.5 pb-2.5">
+                  <span className="text-sm font-semibold text-[var(--text-h)]">{product.name}</span>
+                  {product.discounted_price != null ? (
+                    <div className="flex flex-col gap-0.5">
+                      <span className="text-[13px] text-red-400 line-through opacity-70">
+                        ${parseFloat(product.price).toFixed(2)}
+                      </span>
+                      <span className="text-[15px] font-bold text-purple-400">
+                        ${parseFloat(product.discounted_price).toFixed(2)}
+                        <span className="ml-1.5 text-[11px] font-semibold text-green-400">
+                          -{product.discount_percent}%
+                        </span>
+                      </span>
+                    </div>
+                  ) : (
+                    <span className="text-[15px] font-bold text-purple-400">
+                      ${parseFloat(product.price).toFixed(2)}
+                    </span>
+                  )}
+                  <span
+                    className={
+                      availableStock < 10
+                        ? 'text-[11px] font-semibold text-red-400'
+                        : 'text-[11px] text-[var(--text)] opacity-50'
+                    }
+                  >
+                    {availableStock === 0
+                      ? 'Out of stock'
+                      : availableStock < 10
+                        ? `Only ${availableStock} left`
+                        : `${availableStock} in stock`}
+                  </span>
+                </div>
+                <div className="flex gap-2 px-3 pb-3.5">
+                  <button
+                    className={
+                      outOfStock
+                        ? 'flex flex-1 cursor-not-allowed items-center justify-center gap-1.5 rounded-lg border border-[var(--border)] bg-transparent px-3 py-2.5 text-[13px] font-semibold text-[var(--text)] opacity-40'
+                        : inCart
+                          ? 'flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-lg border border-purple-400 bg-transparent px-3 py-2.5 text-[13px] font-semibold text-purple-400 transition-opacity hover:opacity-88'
+                          : 'flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-none bg-purple-400 px-3 py-2.5 text-[13px] font-semibold text-white transition-opacity hover:opacity-88'
+                    }
+                    disabled={outOfStock && !inCart}
+                    onClick={() =>
+                      outOfStock
+                        ? undefined
+                        : inCart
+                          ? onRemoveFromCart && onRemoveFromCart(product.id)
+                          : onAddToCart && onAddToCart(product)
+                    }
+                  >
+                    <CartIcon />{' '}
+                    {outOfStock ? 'Out of Stock' : inCart ? 'Remove from Cart' : 'Add to Cart'}
+                  </button>
+                  <button
+                    className={
+                      inWishlist
+                        ? 'flex h-[38px] w-[38px] shrink-0 cursor-pointer items-center justify-center rounded-lg border border-purple-400 bg-purple-400/12 text-purple-400 transition-colors'
+                        : 'flex h-[38px] w-[38px] shrink-0 cursor-pointer items-center justify-center rounded-lg border border-[var(--border)] bg-transparent text-[var(--text)] transition-colors hover:border-purple-400 hover:text-purple-400'
+                    }
+                    aria-label={inWishlist ? 'Remove from wishlist' : 'Add to wishlist'}
+                    onClick={() =>
+                      inWishlist
+                        ? onRemoveFromWishlist && onRemoveFromWishlist(product.id)
+                        : onAddToWishlist && onAddToWishlist(product)
+                    }
+                  >
+                    <HeartIcon filled={inWishlist} />
+                  </button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/search/SearchPage.jsx
+++ b/frontend/src/pages/search/SearchPage.jsx
@@ -91,8 +91,6 @@ export default function SearchPage({
   const loading = loadedQuery !== searchQuery
 
   useEffect(() => {
-    setInputValue(searchQuery)
-
     let cancelled = false
     fetch(`${API_BASE}/api/products/search?q=${encodeURIComponent(searchQuery)}`)
       .then((r) => r.json())

--- a/frontend/test/Navbar.test.jsx
+++ b/frontend/test/Navbar.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
 import Navbar from '../src/pages/home/components/Navbar'
 import { ThemeProvider } from '../src/context/ThemeContext'
 
@@ -18,9 +19,11 @@ const defaultProps = {
 
 function renderNavbar(props = {}) {
   return render(
-    <ThemeProvider>
-      <Navbar {...defaultProps} {...props} />
-    </ThemeProvider>
+    <MemoryRouter>
+      <ThemeProvider>
+        <Navbar {...defaultProps} {...props} />
+      </ThemeProvider>
+    </MemoryRouter>
   )
 }
 

--- a/frontend/test/SearchPage.test.jsx
+++ b/frontend/test/SearchPage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import { render, screen, waitForElementToBeRemoved, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
@@ -297,5 +297,38 @@ describe('SearchPage', () => {
     await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
 
     expect(screen.queryByRole('button', { name: /add to cart/i })).not.toBeInTheDocument()
+  })
+
+  it('shows error message on fetch failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
+
+    renderPage()
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
+
+    expect(screen.getByText(/failed to load products/i)).toBeInTheDocument()
+  })
+
+  it('syncs the input value when searchQuery prop changes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ products: [] }),
+      })
+    )
+
+    const { rerender } = renderPage({ searchQuery: 'laptop' })
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
+
+    rerender(
+      <MemoryRouter>
+        <SearchPage {...defaultProps} searchQuery="boots" />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/search products/i)).toHaveValue('boots')
+    })
   })
 })

--- a/frontend/test/SearchPage.test.jsx
+++ b/frontend/test/SearchPage.test.jsx
@@ -68,9 +68,7 @@ describe('SearchPage', () => {
     renderPage({ searchQuery: 'running shoes' })
 
     await vi.waitFor(() => {
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('q=running%20shoes')
-      )
+      expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('q=running%20shoes'))
     })
 
     await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
@@ -137,9 +135,7 @@ describe('SearchPage', () => {
 
     renderPage({ searchQuery: 'zzznomatch' })
 
-    expect(
-      await screen.findByText(/no products found for "zzznomatch"/i)
-    ).toBeInTheDocument()
+    expect(await screen.findByText(/no products found for "zzznomatch"/i)).toBeInTheDocument()
   })
 
   it('fetches all products when searchQuery is empty and shows them', async () => {
@@ -148,7 +144,9 @@ describe('SearchPage', () => {
       vi.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
-          products: [{ id: 1, name: 'All Products Item', price: '9.99', stock: 5, available_stock: 5 }],
+          products: [
+            { id: 1, name: 'All Products Item', price: '9.99', stock: 5, available_stock: 5 },
+          ],
         }),
       })
     )

--- a/frontend/test/SearchPage.test.jsx
+++ b/frontend/test/SearchPage.test.jsx
@@ -1,0 +1,303 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import SearchPage from '../src/pages/search/SearchPage'
+
+const defaultProps = {
+  searchQuery: 'laptop',
+  onBack: vi.fn(),
+  onAddToCart: vi.fn(),
+  onRemoveFromCart: vi.fn(),
+  onAddToWishlist: vi.fn(),
+  onRemoveFromWishlist: vi.fn(),
+  cartItems: [],
+  wishlistItems: [],
+}
+
+function renderPage(props = {}) {
+  return render(
+    <MemoryRouter>
+      <SearchPage {...defaultProps} {...props} />
+    </MemoryRouter>
+  )
+}
+
+describe('SearchPage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows loading state initially', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
+
+    renderPage()
+
+    expect(screen.getByText(/loading products/i)).toBeInTheDocument()
+  })
+
+  it('fetches from the search endpoint with the correct query', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ products: [] }),
+      })
+    )
+
+    renderPage({ searchQuery: 'laptop' })
+
+    await vi.waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/products/search?q=laptop')
+      )
+    })
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
+  })
+
+  it('URL-encodes the search query in the fetch URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ products: [] }),
+      })
+    )
+
+    renderPage({ searchQuery: 'running shoes' })
+
+    await vi.waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('q=running%20shoes')
+      )
+    })
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
+  })
+
+  it('renders product name and price after fetch', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'Laptop Pro', price: '1299.99', stock: 5, available_stock: 5 }],
+        }),
+      })
+    )
+
+    renderPage()
+
+    expect(await screen.findByText('Laptop Pro')).toBeInTheDocument()
+    expect(screen.getByText('$1299.99')).toBeInTheDocument()
+  })
+
+  it('shows "Out of stock" badge when available_stock is 0', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'Laptop Pro', price: '999.99', stock: 0, available_stock: 0 }],
+        }),
+      })
+    )
+
+    renderPage()
+
+    expect(await screen.findByText('Out of stock')).toBeInTheDocument()
+  })
+
+  it('disables add-to-cart button for out-of-stock products', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'Laptop Pro', price: '999.99', stock: 0, available_stock: 0 }],
+        }),
+      })
+    )
+
+    renderPage()
+
+    const button = await screen.findByRole('button', { name: /out of stock/i })
+    expect(button).toBeDisabled()
+  })
+
+  it('shows "No products found for" message when results are empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ products: [] }),
+      })
+    )
+
+    renderPage({ searchQuery: 'zzznomatch' })
+
+    expect(
+      await screen.findByText(/no products found for "zzznomatch"/i)
+    ).toBeInTheDocument()
+  })
+
+  it('fetches all products when searchQuery is empty and shows them', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'All Products Item', price: '9.99', stock: 5, available_stock: 5 }],
+        }),
+      })
+    )
+
+    renderPage({ searchQuery: '' })
+
+    expect(await screen.findByText('All Products Item')).toBeInTheDocument()
+    expect(screen.getByText('All Products')).toBeInTheDocument()
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/products/search?q=')
+    )
+  })
+
+  it('shows "Remove from Cart" when product is already in cartItems', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'Laptop Pro', price: '999.99', stock: 5, available_stock: 5 }],
+        }),
+      })
+    )
+
+    renderPage({ cartItems: [{ id: 1, name: 'Laptop Pro' }] })
+
+    expect(await screen.findByRole('button', { name: /remove from cart/i })).toBeInTheDocument()
+  })
+
+  it('calls onAddToCart when "Add to Cart" is clicked for in-stock product', async () => {
+    const onAddToCart = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'Laptop Pro', price: '999.99', stock: 5, available_stock: 5 }],
+        }),
+      })
+    )
+
+    renderPage({ onAddToCart })
+
+    await userEvent.click(await screen.findByRole('button', { name: /add to cart/i }))
+
+    expect(onAddToCart).toHaveBeenCalledOnce()
+    expect(onAddToCart).toHaveBeenCalledWith(expect.objectContaining({ id: 1, name: 'Laptop Pro' }))
+  })
+
+  it('calls onRemoveFromCart when "Remove from Cart" is clicked', async () => {
+    const onRemoveFromCart = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'Laptop Pro', price: '999.99', stock: 5, available_stock: 5 }],
+        }),
+      })
+    )
+
+    renderPage({ cartItems: [{ id: 1, name: 'Laptop Pro' }], onRemoveFromCart })
+
+    await userEvent.click(await screen.findByRole('button', { name: /remove from cart/i }))
+
+    expect(onRemoveFromCart).toHaveBeenCalledWith(1)
+  })
+
+  it('calls onAddToWishlist when wishlist button is clicked for item not in wishlist', async () => {
+    const onAddToWishlist = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'Laptop Pro', price: '999.99', stock: 5, available_stock: 5 }],
+        }),
+      })
+    )
+
+    renderPage({ onAddToWishlist })
+
+    await userEvent.click(await screen.findByRole('button', { name: /add to wishlist/i }))
+
+    expect(onAddToWishlist).toHaveBeenCalledOnce()
+  })
+
+  it('calls onRemoveFromWishlist when wishlist button is clicked for item in wishlist', async () => {
+    const onRemoveFromWishlist = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [{ id: 1, name: 'Laptop Pro', price: '999.99', stock: 5, available_stock: 5 }],
+        }),
+      })
+    )
+
+    renderPage({ wishlistItems: [{ id: 1, name: 'Laptop Pro' }], onRemoveFromWishlist })
+
+    await userEvent.click(await screen.findByRole('button', { name: /remove from wishlist/i }))
+
+    expect(onRemoveFromWishlist).toHaveBeenCalledWith(1)
+  })
+
+  it('calls onBack when Back button is clicked', async () => {
+    const onBack = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ products: [] }),
+      })
+    )
+
+    renderPage({ onBack })
+
+    await userEvent.click(screen.getByRole('button', { name: /back/i }))
+
+    expect(onBack).toHaveBeenCalledOnce()
+  })
+
+  it('shows result count when products are found', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          products: [
+            { id: 1, name: 'Laptop Pro', price: '999.99', stock: 5, available_stock: 5 },
+            { id: 2, name: 'Laptop Stand', price: '49.99', stock: 8, available_stock: 8 },
+          ],
+        }),
+      })
+    )
+
+    renderPage()
+
+    expect(await screen.findByText('2 products found')).toBeInTheDocument()
+  })
+
+  it('renders empty grid and no cart buttons on fetch error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
+
+    renderPage()
+
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
+
+    expect(screen.queryByRole('button', { name: /add to cart/i })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /api/products/search?q=` — case-insensitive, partial-match search against product name and description using PostgreSQL `ILIKE`
- Empty query returns all products (alphabetical order); single-character queries are rejected early to avoid noise
- New `SearchPage` component renders results in the same card format as the category page, including out-of-stock labelling and disabled add-to-cart
- Wires the existing Navbar search bar to navigate to `/search?q=...` on submit; added a right-side "Search" button
- Back button from search always returns to the previous page (uses `replace: true` on refinement to avoid stacking history entries)
- Guests and logged-in users can search freely (no auth required)

## Test plan

- [x] Run `cd backend && npx jest products-search` — 10 tests pass
- [x] Run `cd frontend && npx vitest run SearchPage` — 16 tests pass
- [x] Type a partial term ("lap") in the Navbar search bar → navigates to `/search?q=lap`, shows Laptop products
- [x] Search an empty string → navigates to `/search`, shows all products alphabetically
- [x] Type a single character ("a") → does not navigate
- [x] Search a term with no matches → shows "No products found for '...'"
- [x] Out-of-stock products appear with "Out of Stock" label and disabled button
- [x] Back button from search results returns directly to home (not through previous queries)
- [x] Guest (logged out) can search freely