### PR TITLE
SCRUM-71: Add product detail fields migration

### DIFF
--- a/backend/migrations/18_product_missing_fields.js
+++ b/backend/migrations/18_product_missing_fields.js
@@ -1,0 +1,33 @@
+exports.options = { transaction: false }
+
+exports.up = (pgm) => {
+  pgm.addColumn(
+    { schema: 'public', name: 'products' },
+    {
+      model: {
+        type: 'varchar(255)',
+        notNull: false,
+      },
+      serial_number: {
+        type: 'varchar(255)',
+        notNull: false,
+        unique: true,
+      },
+      warranty_status: {
+        type: 'varchar(255)',
+        notNull: false,
+      },
+      distributor_info: {
+        type: 'text',
+        notNull: false,
+      },
+    }
+  )
+}
+
+exports.down = (pgm) => {
+  pgm.dropColumn({ schema: 'public', name: 'products' }, 'model')
+  pgm.dropColumn({ schema: 'public', name: 'products' }, 'serial_number')
+  pgm.dropColumn({ schema: 'public', name: 'products' }, 'warranty_status')
+  pgm.dropColumn({ schema: 'public', name: 'products' }, 'distributor_info')
+}


### PR DESCRIPTION
## Summary
- Promotes stashed migration 18 from `.claude/pending-migrations/` into `backend/migrations/`
- Adds `model`, `serial_number`, `warranty_status`, and `distributor_info` columns to the `products` table (Req 7)

## Test plan
- [x] Run `docker compose exec backend npm run migrate:up` — should apply migration 18 with no errors
- [x] Run `docker compose exec backend npm run migrate:down` — should roll back cleanly