### PR TITLE
SCRUM-71: Add product detail fields migration

### DIFF
--- a/backend/.prettierignore
+++ b/backend/.prettierignore
@@ -2,3 +2,4 @@ coverage/
 node_modules/
 dist/
 build/
+.pytest_cache/

--- a/backend/migrations/18_product_missing_fields.js
+++ b/backend/migrations/18_product_missing_fields.js
@@ -21,10 +21,5 @@ exports.up = (pgm) => {
 }
 
 exports.down = (pgm) => {
-  pgm.dropColumns('products', [
-    'model',
-    'serial_number',
-    'warranty_status',
-    'distributor_info',
-  ])
+  pgm.dropColumns('products', ['model', 'serial_number', 'warranty_status', 'distributor_info'])
 }

--- a/backend/migrations/18_product_missing_fields.js
+++ b/backend/migrations/18_product_missing_fields.js
@@ -1,0 +1,33 @@
+exports.options = { transaction: false }
+
+exports.up = (pgm) => {
+  pgm.addColumn(
+    { schema: 'public', name: 'products' },
+    {
+      model: {
+        type: 'varchar(255)',
+        notNull: false,
+      },
+      serial_number: {
+        type: 'varchar(255)',
+        notNull: false,
+        unique: true,
+      },
+      warranty_status: {
+        type: 'varchar(255)',
+        notNull: false,
+      },
+      distributor_info: {
+        type: 'text',
+        notNull: false,
+      },
+    }
+  )
+}
+
+exports.down = (pgm) => {
+  pgm.dropColumn({ schema: 'public', name: 'products' }, 'model')
+  pgm.dropColumn({ schema: 'public', name: 'products' }, 'serial_number')
+  pgm.dropColumn({ schema: 'public', name: 'products' }, 'warranty_status')
+  pgm.dropColumn({ schema: 'public', name: 'products' }, 'distributor_info')
+}

--- a/backend/migrations/18_product_missing_fields.js
+++ b/backend/migrations/18_product_missing_fields.js
@@ -1,33 +1,30 @@
-exports.options = { transaction: false }
-
 exports.up = (pgm) => {
-  pgm.addColumn(
-    { schema: 'public', name: 'products' },
-    {
-      model: {
-        type: 'varchar(255)',
-        notNull: false,
-      },
-      serial_number: {
-        type: 'varchar(255)',
-        notNull: false,
-        unique: true,
-      },
-      warranty_status: {
-        type: 'varchar(255)',
-        notNull: false,
-      },
-      distributor_info: {
-        type: 'text',
-        notNull: false,
-      },
-    }
-  )
+  pgm.addColumns('products', {
+    model: {
+      type: 'varchar(255)',
+      notNull: false,
+    },
+    serial_number: {
+      type: 'varchar(255)',
+      notNull: false,
+      unique: true,
+    },
+    warranty_status: {
+      type: 'varchar(255)',
+      notNull: false,
+    },
+    distributor_info: {
+      type: 'text',
+      notNull: false,
+    },
+  })
 }
 
 exports.down = (pgm) => {
-  pgm.dropColumn({ schema: 'public', name: 'products' }, 'model')
-  pgm.dropColumn({ schema: 'public', name: 'products' }, 'serial_number')
-  pgm.dropColumn({ schema: 'public', name: 'products' }, 'warranty_status')
-  pgm.dropColumn({ schema: 'public', name: 'products' }, 'distributor_info')
+  pgm.dropColumns('products', [
+    'model',
+    'serial_number',
+    'warranty_status',
+    'distributor_info',
+  ])
 }


### PR DESCRIPTION
## Summary
- Adds migration 18: `model`, `serial_number`, `warranty_status`, `distributor_info` columns to `products` (Req 7)
- Addresses Copilot review comments from #69: use `addColumns`/`dropColumns` for style consistency; remove `transaction: false` since plain `ADD COLUMN` is fully transactional

## Test plan
- [x] `docker compose exec backend npm run migrate:up` — migration 18 applies cleanly
- [x] `docker compose exec backend npm run migrate:down` — rolls back cleanly
- [x] `\d products` in psql shows all four new columns