### PR TITLE
feat(layout): persistent navbar and product page UI improvements

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -98,7 +98,22 @@ function CategoryRoute({
   )
 }
 
-function ProductRoute({ onAddToCart, onAddToWishlist, onRemoveFromWishlist, wishlistItems }) {
+function ProductRoute({
+  onAddToCart,
+  onAddToWishlist,
+  onRemoveFromWishlist,
+  wishlistItems,
+  cartItems,
+  onUpdateQuantity,
+  isLoggedIn,
+  userEmail,
+  token,
+  onNavigate,
+  onRequireAuth,
+  onLogout,
+  cartCount,
+  wishlistCount,
+}) {
   const { id } = useParams()
   const navigate = useNavigate()
   return (
@@ -109,6 +124,16 @@ function ProductRoute({ onAddToCart, onAddToWishlist, onRemoveFromWishlist, wish
       onAddToWishlist={onAddToWishlist}
       onRemoveFromWishlist={onRemoveFromWishlist}
       wishlistItems={wishlistItems}
+      cartItems={cartItems}
+      onUpdateQuantity={onUpdateQuantity}
+      isLoggedIn={isLoggedIn}
+      userEmail={userEmail}
+      token={token}
+      onNavigate={onNavigate}
+      onRequireAuth={onRequireAuth}
+      onLogout={onLogout}
+      cartCount={cartCount}
+      wishlistCount={wishlistCount}
     />
   )
 }
@@ -507,6 +532,16 @@ function App() {
               onAddToWishlist={addToWishlist}
               onRemoveFromWishlist={removeFromWishlist}
               wishlistItems={wishlist}
+              cartItems={cart}
+              onUpdateQuantity={updateCartQuantity}
+              isLoggedIn={!!token}
+              userEmail={user?.email}
+              token={token}
+              onNavigate={handleNavigate}
+              onRequireAuth={requireAuth}
+              onLogout={handleLogout}
+              cartCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+              wishlistCount={wishlist.length}
             />
           }
         />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import {
   useSearchParams,
   useParams,
 } from 'react-router-dom'
+import Navbar from './pages/home/components/Navbar'
 import AdminLoginPage from './pages/admin/AdminLoginPage'
 import SalesManagerLoginPage from './pages/sales-manager/SalesManagerLoginPage'
 import SalesManagerDashboard from './pages/sales-manager/SalesManagerDashboard'
@@ -41,6 +42,38 @@ function ScrollToTop() {
     if (navType !== 'POP') window.scrollTo(0, 0)
   }, [pathname, navType])
   return null
+}
+
+function CustomerLayout({
+  isLoggedIn,
+  userEmail,
+  token,
+  onNavigate,
+  onRequireAuth,
+  onLogout,
+  cartCount,
+  wishlistCount,
+  children,
+}) {
+  const [searchParams] = useSearchParams()
+  const [searchQuery, setSearchQuery] = useState(() => searchParams.get('q') || '')
+  return (
+    <>
+      <Navbar
+        isLoggedIn={isLoggedIn}
+        userEmail={userEmail}
+        token={token}
+        onNavigate={onNavigate}
+        onRequireAuth={onRequireAuth}
+        onLogout={onLogout}
+        cartCount={cartCount}
+        wishlistCount={wishlistCount}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+      />
+      {children}
+    </>
+  )
 }
 
 function RequireAuth({ token, children }) {
@@ -140,13 +173,11 @@ function ProductRoute({
 
 function SearchRoute({ onAddToWishlist, onRemoveFromWishlist, wishlistItems }) {
   const [searchParams] = useSearchParams()
-  const navigate = useNavigate()
   const q = searchParams.get('q') || ''
 
   return (
     <SearchPage
       searchQuery={q}
-      onBack={() => navigate(-1)}
       onAddToWishlist={onAddToWishlist}
       onRemoveFromWishlist={onRemoveFromWishlist}
       wishlistItems={wishlistItems}
@@ -479,16 +510,27 @@ function App() {
         <Route
           path="/cart"
           element={
-            <CartPage
-              onBack={() => navigate(-1)}
-              cartItems={cart}
-              onRemove={removeFromCart}
-              onUpdateQuantity={updateCartQuantity}
-              onAddToWishlist={addToWishlist}
-              wishlistItems={wishlist}
+            <CustomerLayout
               isLoggedIn={!!token}
+              userEmail={user?.email}
               token={token}
-            />
+              onNavigate={handleNavigate}
+              onRequireAuth={requireAuth}
+              onLogout={handleLogout}
+              cartCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+              wishlistCount={wishlist.length}
+            >
+              <CartPage
+                onBack={() => navigate(-1)}
+                cartItems={cart}
+                onRemove={removeFromCart}
+                onUpdateQuantity={updateCartQuantity}
+                onAddToWishlist={addToWishlist}
+                wishlistItems={wishlist}
+                isLoggedIn={!!token}
+                token={token}
+              />
+            </CustomerLayout>
           }
         />
         <Route
@@ -517,11 +559,22 @@ function App() {
         <Route
           path="/wishlist"
           element={
-            <WishlistPage
-              onBack={() => navigate(-1)}
-              wishlistItems={wishlist}
-              onRemove={removeFromWishlist}
-            />
+            <CustomerLayout
+              isLoggedIn={!!token}
+              userEmail={user?.email}
+              token={token}
+              onNavigate={handleNavigate}
+              onRequireAuth={requireAuth}
+              onLogout={handleLogout}
+              cartCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+              wishlistCount={wishlist.length}
+            >
+              <WishlistPage
+                onBack={() => navigate(-1)}
+                wishlistItems={wishlist}
+                onRemove={removeFromWishlist}
+              />
+            </CustomerLayout>
           }
         />
         <Route
@@ -560,30 +613,79 @@ function App() {
         <Route
           path="/search"
           element={
-            <SearchRoute
-              onAddToWishlist={addToWishlist}
-              onRemoveFromWishlist={removeFromWishlist}
-              wishlistItems={wishlist}
-            />
+            <CustomerLayout
+              isLoggedIn={!!token}
+              userEmail={user?.email}
+              token={token}
+              onNavigate={handleNavigate}
+              onRequireAuth={requireAuth}
+              onLogout={handleLogout}
+              cartCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+              wishlistCount={wishlist.length}
+            >
+              <SearchRoute
+                onAddToWishlist={addToWishlist}
+                onRemoveFromWishlist={removeFromWishlist}
+                wishlistItems={wishlist}
+              />
+            </CustomerLayout>
           }
         />
         <Route
           path="/account-settings"
           element={
-            <RequireAuth token={token}>
-              <AccountSettingsPage onBack={() => navigate(-1)} token={token} />
-            </RequireAuth>
+            <CustomerLayout
+              isLoggedIn={!!token}
+              userEmail={user?.email}
+              token={token}
+              onNavigate={handleNavigate}
+              onRequireAuth={requireAuth}
+              onLogout={handleLogout}
+              cartCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+              wishlistCount={wishlist.length}
+            >
+              <RequireAuth token={token}>
+                <AccountSettingsPage token={token} />
+              </RequireAuth>
+            </CustomerLayout>
           }
         />
         <Route
           path="/orders"
           element={
-            <RequireAuth token={token}>
-              <OrdersPage onBack={() => navigate(-1)} token={token} />
-            </RequireAuth>
+            <CustomerLayout
+              isLoggedIn={!!token}
+              userEmail={user?.email}
+              token={token}
+              onNavigate={handleNavigate}
+              onRequireAuth={requireAuth}
+              onLogout={handleLogout}
+              cartCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+              wishlistCount={wishlist.length}
+            >
+              <RequireAuth token={token}>
+                <OrdersPage token={token} />
+              </RequireAuth>
+            </CustomerLayout>
           }
         />
-        <Route path="/help" element={<HelpPage onBack={() => navigate(-1)} />} />
+        <Route
+          path="/help"
+          element={
+            <CustomerLayout
+              isLoggedIn={!!token}
+              userEmail={user?.email}
+              token={token}
+              onNavigate={handleNavigate}
+              onRequireAuth={requireAuth}
+              onLogout={handleLogout}
+              cartCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+              wishlistCount={wishlist.length}
+            >
+              <HelpPage />
+            </CustomerLayout>
+          }
+        />
 
         {/* Sales manager routes */}
         <Route

--- a/frontend/src/pages/account/AccountSettingsPage.jsx
+++ b/frontend/src/pages/account/AccountSettingsPage.jsx
@@ -1,26 +1,7 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import API_BASE from '../../api'
-
-function BackIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </svg>
-  )
-}
 
 function Section({ title, description, children }) {
   return (
@@ -55,7 +36,7 @@ function Toggle({ checked, onChange, label }) {
   )
 }
 
-export default function AccountSettingsPage({ onBack, token }) {
+export default function AccountSettingsPage({ token }) {
   // ... rest of state stays same ...
   // Profile
   const [name, setName] = useState('Jane Smith')
@@ -138,24 +119,6 @@ export default function AccountSettingsPage({ onBack, token }) {
 
   return (
     <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
-      <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-        <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-            onClick={onBack}
-          >
-            <BackIcon /> Back
-          </button>
-          <Link
-            to="/"
-            className="ml-auto cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-          >
-            FIER
-          </Link>
-        </div>
-      </header>
-
       <main className="mx-auto box-border w-full max-w-[760px] px-6 pt-12 pb-20">
         <h1 className="mb-10 text-[32px] font-extrabold tracking-[-0.5px] text-[var(--text-h)]">
           Account Settings

--- a/frontend/src/pages/cart/CartPage.jsx
+++ b/frontend/src/pages/cart/CartPage.jsx
@@ -4,24 +4,6 @@ import CatalogImage from '../../components/catalog/CatalogImage'
 import API_BASE from '../../api'
 import { getProductImageUrl } from '../../lib/catalogAssets'
 
-function BackIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </svg>
-  )
-}
-
 function TrashIcon() {
   return (
     <svg
@@ -98,23 +80,6 @@ export default function CartPage({
   if (cartItems.length === 0) {
     return (
       <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
-        <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-          <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-            <button
-              type="button"
-              className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-              onClick={onBack}
-            >
-              <BackIcon /> Back
-            </button>
-            <Link
-              to="/"
-              className="ml-auto cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-            >
-              FIER
-            </Link>
-          </div>
-        </header>
         <main className="mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
           <h1 className="mb-10 text-[32px] font-bold tracking-[-0.5px] text-[var(--text-h)]">
             Shopping Cart
@@ -155,24 +120,6 @@ export default function CartPage({
 
   return (
     <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
-      <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-        <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-            onClick={onBack}
-          >
-            <BackIcon /> Back
-          </button>
-          <Link
-            to="/"
-            className="ml-auto cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-          >
-            FIER
-          </Link>
-        </div>
-      </header>
-
       <main className="mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
         <h1 className="mb-10 text-[32px] font-bold tracking-[-0.5px] text-[var(--text-h)]">
           Shopping Cart

--- a/frontend/src/pages/help/HelpPage.jsx
+++ b/frontend/src/pages/help/HelpPage.jsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react'
-import { Link } from 'react-router-dom'
 
 /* ── FAQ data ─────────────────────────────────────────────── */
 
@@ -231,24 +230,6 @@ const FAQ_CATEGORIES = [
 
 /* ── Icons ────────────────────────────────────────────────── */
 
-function BackIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </svg>
-  )
-}
-
 function SearchIcon() {
   return (
     <svg
@@ -316,7 +297,7 @@ function FaqItem({ question, answer }) {
 
 /* ── Page ─────────────────────────────────────────────────── */
 
-export default function HelpPage({ onBack }) {
+export default function HelpPage() {
   const [search, setSearch] = useState('')
   const [activeCategory, setActiveCategory] = useState('all')
 
@@ -334,24 +315,6 @@ export default function HelpPage({ onBack }) {
 
   return (
     <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
-      <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-        <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-            onClick={onBack}
-          >
-            <BackIcon /> Back
-          </button>
-          <Link
-            to="/"
-            className="ml-auto cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-          >
-            FIER
-          </Link>
-        </div>
-      </header>
-
       {/* Hero */}
       <div className="flex flex-col items-center gap-3 bg-[linear-gradient(135deg,var(--bg)_0%,var(--bg-gradient-to)_50%,var(--accent-bg)_100%)] px-6 py-16 text-center">
         <p className="m-0 text-[11px] font-bold tracking-[5px] text-purple-400 uppercase">

--- a/frontend/src/pages/home/components/Navbar.jsx
+++ b/frontend/src/pages/home/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import {
   CartIcon,
   WishlistIcon,
@@ -53,9 +53,12 @@ export default function Navbar({
     <header className="light:bg-white/95 light:shadow-[0_2px_15px_rgba(0,0,0,0.08)] fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb,16,13,30),0.75)] px-6 backdrop-blur-xl">
       <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-6">
         {/* Brand */}
-        <div className="shrink-0 text-[22px] font-bold tracking-[4px] text-[var(--text-h)]">
+        <Link
+          to="/"
+          className="shrink-0 text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
+        >
           FIER
-        </div>
+        </Link>
 
         {/* Search bar */}
         <form

--- a/frontend/src/pages/orders/OrdersPage.jsx
+++ b/frontend/src/pages/orders/OrdersPage.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
-import { Link } from 'react-router-dom'
 import API_BASE from '../../api'
 
 /* ── Status mapping ──────────────────────────────────────── */
@@ -42,24 +41,6 @@ function nameHue(name) {
 }
 
 /* ── Icons ───────────────────────────────────────────────── */
-
-function BackIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </svg>
-  )
-}
 
 function CheckIcon() {
   return (
@@ -565,7 +546,7 @@ function OrderItems({ items, orderCreatedAt, orderStatus, token, onRefundChange 
 
 /* ── Page ────────────────────────────────────────────────── */
 
-export default function OrdersPage({ onBack, token }) {
+export default function OrdersPage({ token }) {
   const [orders, setOrders] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -631,24 +612,6 @@ export default function OrdersPage({ onBack, token }) {
 
   return (
     <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
-      <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-        <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-            onClick={onBack}
-          >
-            <BackIcon /> Back
-          </button>
-          <Link
-            to="/"
-            className="ml-auto cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-          >
-            FIER
-          </Link>
-        </div>
-      </header>
-
       <main className="mx-auto box-border w-full max-w-[860px] px-6 pt-12 pb-20">
         <h1 className="mb-10 text-[32px] font-extrabold tracking-[-0.5px] text-[var(--text-h)]">
           My Orders

--- a/frontend/src/pages/product/ProductPage.jsx
+++ b/frontend/src/pages/product/ProductPage.jsx
@@ -214,7 +214,7 @@ export default function ProductPage({
   const outOfStock = availableStock === 0
   const inWishlist = wishlistItems.some((i) => i.id === product.id)
   const cartItem = cartItems.find(
-    (i) => i.id === product.id && (i.size || '') === (selectedSize || ''),
+    (i) => i.id === product.id && (i.size || '') === (selectedSize || '')
   )
   const currentQty = cartItem?.quantity ?? 0
   const galleryImages = getResolvedProductImages(product, images)
@@ -238,8 +238,18 @@ export default function ProductPage({
           onClick={onBack}
           className="mb-6 flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="19" y1="12" x2="5" y2="12" /><polyline points="12 19 5 12 12 5" />
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="19" y1="12" x2="5" y2="12" />
+            <polyline points="12 19 5 12 12 5" />
           </svg>
           Back
         </button>
@@ -681,4 +691,3 @@ export default function ProductPage({
     </div>
   )
 }
-

--- a/frontend/src/pages/product/ProductPage.jsx
+++ b/frontend/src/pages/product/ProductPage.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Link } from 'react-router-dom'
 import { StarRating } from '../../components/icons'
 import CatalogImage from '../../components/catalog/CatalogImage'
 import Footer from '../home/components/Footer'
+import Navbar from '../home/components/Navbar'
 import API_BASE from '../../api'
 import { getResolvedProductImages } from '../../lib/catalogAssets'
 
@@ -15,24 +15,6 @@ const CATEGORY_HUE = {
   Activewear: 340,
   Formal: 260,
   'Kids & Baby': 20,
-}
-
-function BackIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </svg>
-  )
 }
 
 function HeartIcon({ filled }) {
@@ -107,6 +89,16 @@ export default function ProductPage({
   onAddToWishlist,
   onRemoveFromWishlist,
   wishlistItems = [],
+  cartItems = [],
+  onUpdateQuantity,
+  isLoggedIn,
+  userEmail,
+  token,
+  onNavigate,
+  onRequireAuth,
+  onLogout,
+  cartCount,
+  wishlistCount,
 }) {
   const [product, setProduct] = useState(null)
   const [images, setImages] = useState([])
@@ -115,6 +107,7 @@ export default function ProductPage({
   const [error, setError] = useState('')
   const [selectedSize, setSelectedSize] = useState(null)
   const [sizeError, setSizeError] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const [reviews, setReviews] = useState([])
   const [avgRating, setAvgRating] = useState(null)
@@ -177,11 +170,26 @@ export default function ProductPage({
     />
   )
 
+  const navbar = (
+    <Navbar
+      isLoggedIn={isLoggedIn}
+      userEmail={userEmail}
+      token={token}
+      onNavigate={onNavigate}
+      onRequireAuth={onRequireAuth}
+      onLogout={onLogout}
+      cartCount={cartCount}
+      wishlistCount={wishlistCount}
+      searchQuery={searchQuery}
+      setSearchQuery={setSearchQuery}
+    />
+  )
+
   if (loading) {
     return (
       <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
         {ambientBg}
-        <Header onBack={onBack} />
+        {navbar}
         <main className="relative z-[1] mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
           <p className="text-[var(--text)] opacity-60">Loading…</p>
         </main>
@@ -193,7 +201,7 @@ export default function ProductPage({
     return (
       <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
         {ambientBg}
-        <Header onBack={onBack} />
+        {navbar}
         <main className="relative z-[1] mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
           <p className="text-red-400">{error || 'Product not found'}</p>
         </main>
@@ -205,6 +213,10 @@ export default function ProductPage({
   const availableStock = parseInt(product.available_stock ?? product.stock ?? 0)
   const outOfStock = availableStock === 0
   const inWishlist = wishlistItems.some((i) => i.id === product.id)
+  const cartItem = cartItems.find(
+    (i) => i.id === product.id && (i.size || '') === (selectedSize || ''),
+  )
+  const currentQty = cartItem?.quantity ?? 0
   const galleryImages = getResolvedProductImages(product, images)
   const avgRatingRounded = avgRating ? Math.round(parseFloat(avgRating)) : null
 
@@ -218,9 +230,19 @@ export default function ProductPage({
   return (
     <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
       {ambientBg}
-      <Header onBack={onBack} />
+      {navbar}
 
-      <main className="relative z-[1] mx-auto box-border w-full max-w-[1280px] px-6 pt-10 pb-20">
+      <main className="relative z-[1] mx-auto box-border w-full max-w-[1280px] px-6 pt-6 pb-20">
+        <button
+          type="button"
+          onClick={onBack}
+          className="mb-6 flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="19" y1="12" x2="5" y2="12" /><polyline points="12 19 5 12 12 5" />
+          </svg>
+          Back
+        </button>
         {/* ── Top section: image gallery + info ── */}
         <div className="grid gap-10 max-[720px]:grid-cols-1 lg:grid-cols-[5fr_7fr]">
           {/* Image gallery */}
@@ -493,19 +515,43 @@ export default function ProductPage({
 
             {/* Add to cart + wishlist */}
             <div className="flex gap-3">
-              <button
-                type="button"
-                disabled={outOfStock}
-                onClick={outOfStock ? undefined : handleAddToCart}
-                className={
-                  outOfStock
-                    ? 'flex flex-1 cursor-not-allowed items-center justify-center gap-2 rounded-xl border border-[var(--border)] bg-transparent px-5 py-3 text-[14px] font-semibold text-[var(--text)] opacity-40'
-                    : 'flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border-none bg-purple-400 px-5 py-3 text-[14px] font-semibold text-white transition-opacity hover:opacity-88'
-                }
-              >
-                <CartIcon />
-                {outOfStock ? 'Out of Stock' : 'Add to Cart'}
-              </button>
+              {currentQty > 0 ? (
+                <div className="flex flex-1 items-center justify-between rounded-xl border border-purple-400 bg-purple-400/10 px-4 py-3">
+                  <button
+                    type="button"
+                    onClick={() => onUpdateQuantity(product.id, selectedSize || '', currentQty - 1)}
+                    className="flex cursor-pointer items-center justify-center border-none bg-transparent text-xl leading-none text-[var(--text-h)] transition-colors hover:text-purple-400"
+                    aria-label="Decrease quantity"
+                  >
+                    −
+                  </button>
+                  <span className="text-[14px] font-semibold text-[var(--text-h)]">
+                    {currentQty} in cart
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onUpdateQuantity(product.id, selectedSize || '', currentQty + 1)}
+                    className="flex cursor-pointer items-center justify-center border-none bg-transparent text-xl leading-none text-[var(--text-h)] transition-colors hover:text-purple-400"
+                    aria-label="Increase quantity"
+                  >
+                    +
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  disabled={outOfStock}
+                  onClick={outOfStock ? undefined : handleAddToCart}
+                  className={
+                    outOfStock
+                      ? 'flex flex-1 cursor-not-allowed items-center justify-center gap-2 rounded-xl border border-[var(--border)] bg-transparent px-5 py-3 text-[14px] font-semibold text-[var(--text)] opacity-40'
+                      : 'flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-xl border-none bg-purple-400 px-5 py-3 text-[14px] font-semibold text-white transition-colors hover:opacity-88'
+                  }
+                >
+                  <CartIcon />
+                  {outOfStock ? 'Out of Stock' : 'Add to Cart'}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={() =>
@@ -636,24 +682,3 @@ export default function ProductPage({
   )
 }
 
-function Header({ onBack }) {
-  return (
-    <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-      <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-        <button
-          type="button"
-          className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-          onClick={onBack}
-        >
-          <BackIcon /> Back
-        </button>
-        <Link
-          to="/"
-          className="ml-auto cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-        >
-          FIER
-        </Link>
-      </div>
-    </header>
-  )
-}

--- a/frontend/src/pages/search/SearchPage.jsx
+++ b/frontend/src/pages/search/SearchPage.jsx
@@ -1,45 +1,9 @@
 import { useState, useEffect } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import CatalogImage from '../../components/catalog/CatalogImage'
 import API_BASE from '../../api'
 import { SORT_OPTIONS } from '../../constants/sortOptions'
 import { getProductImageUrl } from '../../lib/catalogAssets'
-
-function BackIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </svg>
-  )
-}
-
-function SearchIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="11" cy="11" r="8" />
-      <line x1="21" y1="21" x2="16.65" y2="16.65" />
-    </svg>
-  )
-}
 
 function HeartIcon({ filled }) {
   return (
@@ -60,14 +24,12 @@ function HeartIcon({ filled }) {
 
 export default function SearchPage({
   searchQuery,
-  onBack,
   onAddToWishlist,
   onRemoveFromWishlist,
   wishlistItems = [],
 }) {
   const [products, setProducts] = useState([])
   const [loadedKey, setLoadedKey] = useState(null)
-  const [inputValue, setInputValue] = useState(searchQuery)
   const [sort, setSort] = useState('newest')
   const [prevSearchQuery, setPrevSearchQuery] = useState(searchQuery)
   const [error, setError] = useState(false)
@@ -108,64 +70,10 @@ export default function SearchPage({
     }
   }, [searchQuery, sort])
 
-  useEffect(() => {
-    setInputValue(searchQuery)
-  }, [searchQuery])
-
-  function handleSearchSubmit(e) {
-    e.preventDefault()
-    const q = inputValue.trim()
-    if (q.length !== 1)
-      navigate(q ? '/search?q=' + encodeURIComponent(q) : '/search', { replace: true })
-  }
-
   const wishlistIds = new Set(wishlistItems.map((i) => i.id))
 
   return (
     <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
-      <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-        <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-            onClick={onBack}
-          >
-            <BackIcon /> Back
-          </button>
-          <form
-            onSubmit={handleSearchSubmit}
-            className="flex h-9 flex-1 items-center gap-2 rounded-[10px] border border-[var(--border)] bg-[var(--card-bg)] px-3 backdrop-blur-xl transition-[border-color] focus-within:border-purple-400/50"
-          >
-            <button
-              type="submit"
-              aria-label="Search"
-              className="flex items-center border-none bg-transparent p-0 text-[var(--text)] hover:text-purple-400"
-            >
-              <SearchIcon />
-            </button>
-            <input
-              type="text"
-              placeholder="Search products…"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              className="flex-1 border-none bg-transparent text-sm text-[var(--text-h)] outline-none placeholder:text-[var(--text)]/40"
-            />
-            <button
-              type="submit"
-              className="shrink-0 rounded-md border-none bg-purple-400/15 px-2.5 py-1 text-[12px] font-semibold text-purple-400 transition-colors hover:bg-purple-400/28"
-            >
-              Search
-            </button>
-          </form>
-          <Link
-            to="/"
-            className="ml-auto shrink-0 cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-          >
-            FIER
-          </Link>
-        </div>
-      </header>
-
       <main className="mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
         <div className="mb-10">
           <p className="m-0 mb-2.5 text-[11px] font-bold tracking-[5px] text-purple-400 uppercase">

--- a/frontend/src/pages/wishlist/WishlistPage.jsx
+++ b/frontend/src/pages/wishlist/WishlistPage.jsx
@@ -2,24 +2,6 @@ import { Link } from 'react-router-dom'
 import CatalogImage from '../../components/catalog/CatalogImage'
 import { getProductImageUrl } from '../../lib/catalogAssets'
 
-function BackIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </svg>
-  )
-}
-
 function TrashIcon() {
   return (
     <svg
@@ -44,23 +26,6 @@ export default function WishlistPage({ onBack, wishlistItems, onRemove }) {
   if (wishlistItems.length === 0) {
     return (
       <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
-        <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-          <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-            <button
-              type="button"
-              className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-              onClick={onBack}
-            >
-              <BackIcon /> Back
-            </button>
-            <Link
-              to="/"
-              className="ml-auto cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-            >
-              FIER
-            </Link>
-          </div>
-        </header>
         <main className="mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
           <h1 className="mb-10 text-[32px] font-bold tracking-[-0.5px] text-[var(--text-h)]">
             Wishlist
@@ -101,21 +66,6 @@ export default function WishlistPage({ onBack, wishlistItems, onRemove }) {
 
   return (
     <div className="flex min-h-svh w-full flex-col bg-[var(--bg)] pt-16">
-      <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-        <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-            onClick={onBack}
-          >
-            <BackIcon /> Back
-          </button>
-          <span className="ml-auto text-[22px] font-bold tracking-[4px] text-[var(--text-h)]">
-            FIER
-          </span>
-        </div>
-      </header>
-
       <main className="mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
         <h1 className="mb-10 text-[32px] font-bold tracking-[-0.5px] text-[var(--text-h)]">
           Wishlist

--- a/frontend/test/CartPage.test.jsx
+++ b/frontend/test/CartPage.test.jsx
@@ -172,15 +172,6 @@ describe('CartPage', () => {
 
     expect(screen.getByText('Free')).toBeInTheDocument()
   })
-
-  it('calls onBack when Back button is clicked', async () => {
-    const onBack = vi.fn()
-    renderPage({ onBack })
-
-    await userEvent.click(screen.getByRole('button', { name: /back/i }))
-
-    expect(onBack).toHaveBeenCalledOnce()
-  })
 })
 
 const outOfStockItem = {
@@ -291,13 +282,5 @@ describe('CartPage — product links', () => {
     const productLinks = allLinks.filter((l) => l.getAttribute('href') === '/product/1')
     // There should be 2 links: thumbnail and name
     expect(productLinks.length).toBe(2)
-  })
-
-  it('FIER logo links to /', () => {
-    renderPage()
-
-    const fierLink = screen.getByRole('link', { name: 'FIER' })
-    expect(fierLink).toBeInTheDocument()
-    expect(fierLink).toHaveAttribute('href', '/')
   })
 })

--- a/frontend/test/ProductPage.test.jsx
+++ b/frontend/test/ProductPage.test.jsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import ProductPage from '../src/pages/product/ProductPage'
+import { ThemeProvider } from '../src/context/ThemeContext'
 
 const mockProduct = {
   id: 1,
@@ -30,7 +31,16 @@ const defaultProps = {
   onAddToWishlist: vi.fn(),
   onRemoveFromWishlist: vi.fn(),
   wishlistItems: [],
+  cartItems: [],
+  onUpdateQuantity: vi.fn(),
+  isLoggedIn: false,
+  userEmail: null,
   token: null,
+  onNavigate: vi.fn(),
+  onRequireAuth: vi.fn(),
+  onLogout: vi.fn(),
+  cartCount: 0,
+  wishlistCount: 0,
 }
 
 function stubFetch({ product = mockProduct, images = [], reviews = [] } = {}) {
@@ -47,9 +57,11 @@ function stubFetch({ product = mockProduct, images = [], reviews = [] } = {}) {
 
 function renderPage(props = {}) {
   return render(
-    <MemoryRouter>
-      <ProductPage {...defaultProps} {...props} />
-    </MemoryRouter>
+    <ThemeProvider>
+      <MemoryRouter>
+        <ProductPage {...defaultProps} {...props} />
+      </MemoryRouter>
+    </ThemeProvider>
   )
 }
 
@@ -244,6 +256,7 @@ describe('ProductPage', () => {
 
     renderPage({ onBack })
 
+    await screen.findByText('Merino Sweater')
     await userEvent.click(screen.getByRole('button', { name: /back/i }))
 
     expect(onBack).toHaveBeenCalledOnce()

--- a/frontend/test/SearchPage.test.jsx
+++ b/frontend/test/SearchPage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitForElementToBeRemoved, waitFor } from '@testing-library/react'
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
@@ -178,23 +178,6 @@ describe('SearchPage', () => {
     expect(onRemoveFromWishlist).toHaveBeenCalledWith(1)
   })
 
-  it('calls onBack when Back button is clicked', async () => {
-    const onBack = vi.fn()
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ products: [] }),
-      })
-    )
-
-    renderPage({ onBack })
-
-    await userEvent.click(screen.getByRole('button', { name: /back/i }))
-
-    expect(onBack).toHaveBeenCalledOnce()
-  })
-
   it('shows result count when products are found', async () => {
     vi.stubGlobal(
       'fetch',
@@ -222,28 +205,5 @@ describe('SearchPage', () => {
     await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
 
     expect(screen.getByText(/failed to load products/i)).toBeInTheDocument()
-  })
-
-  it('syncs the input value when searchQuery prop changes', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ products: [] }),
-      })
-    )
-
-    const { rerender } = renderPage({ searchQuery: 'laptop' })
-    await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
-
-    rerender(
-      <MemoryRouter>
-        <SearchPage {...defaultProps} searchQuery="boots" />
-      </MemoryRouter>
-    )
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/search products/i)).toHaveValue('boots')
-    })
   })
 })

--- a/frontend/test/WishlistPage.test.jsx
+++ b/frontend/test/WishlistPage.test.jsx
@@ -83,15 +83,6 @@ describe('WishlistPage', () => {
     expect(onRemove).toHaveBeenCalledWith(1)
   })
 
-  it('calls onBack when Back button is clicked', async () => {
-    const onBack = vi.fn()
-    renderPage({ onBack })
-
-    await userEvent.click(screen.getByRole('button', { name: /back/i }))
-
-    expect(onBack).toHaveBeenCalledOnce()
-  })
-
   it('"Go to item" link is rendered for each wishlist item', () => {
     renderPage()
 


### PR DESCRIPTION
## Summary

- Replace per-page minimal headers (back button + logo only) with the full customer navbar across all customer-facing pages (cart, wishlist, search, account settings, orders, help), so navigation never disappears between routes
- Add full navbar to the product details page with search, cart, wishlist, notifications, account menu, and theme toggle
- Replace the timed "Added to Cart" flash on the product page with a persistent `− N in cart +` quantity stepper driven by live cart state
- Make the FIER logo a home link on every page

## Test plan

- [ ] Navigate to a product page — full navbar is visible with correct cart/wishlist counts
- [ ] Add a product to cart — button transforms to `− 1 in cart +` stepper immediately; `+` and `−` adjust quantity, hitting 0 reverts to "Add to Cart"
- [ ] Click the FIER logo from any page — navigates to `/`
- [ ] Navigate to `/cart`, `/wishlist`, `/search`, `/account-settings`, `/orders`, `/help` — full navbar is present on all pages with live cart/wishlist counts
- [ ] Cart page still shows product links and renders correctly (no crash)
- [ ] Wishlist, search, and orders pages render without errors
- [ ] Logging out from the account menu on any page works correctly