### PR TITLE
UI improvements: light mode hero, footer links, category navbar

### DIFF
--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -77,9 +77,10 @@ router.get('/search', async (req, res) => {
   res.json({ products: result.rows })
 })
 
-// GET /api/products — list products, optional ?category= ?limit= ?sort=
+// GET /api/products — list products, optional ?category= ?limit= ?sort= ?on_sale=
 router.get('/', async (req, res) => {
   const category = (req.query.category || '').trim()
+  const onSale = req.query.on_sale === 'true'
   const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 50))
 
   let where = []
@@ -90,6 +91,10 @@ router.get('/', async (req, res) => {
     where.push(`p.category = $${idx}`)
     params.push(category)
     idx++
+  }
+
+  if (onSale) {
+    where.push(`pd.discount_percent IS NOT NULL`)
   }
 
   const whereClause = where.length ? `WHERE ${where.join(' AND ')}` : ''

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -626,13 +626,25 @@ function App() {
         <Route
           path="/category"
           element={
-            <CategoryRoute
-              onAddToCart={addToCart}
-              onAddToWishlist={addToWishlist}
-              onRemoveFromWishlist={removeFromWishlist}
-              wishlistItems={wishlist}
+            <CustomerLayout
+              isLoggedIn={!!token}
+              userEmail={user?.email}
+              userName={user?.name}
               token={token}
-            />
+              onNavigate={handleNavigate}
+              onRequireAuth={requireAuth}
+              onLogout={handleLogout}
+              cartCount={cart.reduce((sum, item) => sum + item.quantity, 0)}
+              wishlistCount={wishlist.length}
+            >
+              <CategoryRoute
+                onAddToCart={addToCart}
+                onAddToWishlist={addToWishlist}
+                onRemoveFromWishlist={removeFromWishlist}
+                wishlistItems={wishlist}
+                token={token}
+              />
+            </CustomerLayout>
           }
         />
         <Route

--- a/frontend/src/pages/category/CategoryPage.jsx
+++ b/frontend/src/pages/category/CategoryPage.jsx
@@ -68,10 +68,11 @@ export default function CategoryPage({
     let cancelled = false
     const requestKey = `${category.title}::${sort}`
 
-    fetchJsonWithRetry(
-      `${API_BASE}/api/products?category=${encodeURIComponent(category.title)}&sort=${sort}`,
-      { attempts: 1 }
-    )
+    const apiUrl = category.on_sale
+      ? `${API_BASE}/api/products?on_sale=true&sort=${sort}&limit=100`
+      : `${API_BASE}/api/products?category=${encodeURIComponent(category.title)}&sort=${sort}`
+
+    fetchJsonWithRetry(apiUrl, { attempts: 1 })
       .then((data) => {
         if (!cancelled) {
           setProducts(data.products ?? [])
@@ -89,7 +90,7 @@ export default function CategoryPage({
     return () => {
       cancelled = true
     }
-  }, [category.title, sort])
+  }, [category.title, category.on_sale, sort])
 
   const wishlistIds = new Set(wishlistItems.map((i) => i.id))
 

--- a/frontend/src/pages/category/CategoryPage.jsx
+++ b/frontend/src/pages/category/CategoryPage.jsx
@@ -1,29 +1,11 @@
 import { useState, useEffect } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import CatalogImage from '../../components/catalog/CatalogImage'
 import Footer from '../home/components/Footer'
 import API_BASE from '../../api'
 import { SORT_OPTIONS } from '../../constants/sortOptions'
 import { getProductImageUrl } from '../../lib/catalogAssets'
 import { fetchJsonWithRetry } from '../../lib/fetchJsonWithRetry'
-
-function BackIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </svg>
-  )
-}
 
 function HeartIcon({ filled }) {
   return (
@@ -44,7 +26,6 @@ function HeartIcon({ filled }) {
 
 export default function CategoryPage({
   category,
-  onBack,
   onAddToWishlist,
   onRemoveFromWishlist,
   wishlistItems = [],
@@ -104,24 +85,6 @@ export default function CategoryPage({
         }}
         aria-hidden="true"
       />
-      <header className="fixed top-0 right-0 left-0 z-[1000] border-b border-[var(--border)] bg-[rgba(var(--background-rgb),0.75)] px-6 backdrop-blur-[20px]">
-        <div className="mx-auto flex h-16 max-w-[1280px] items-center gap-4">
-          <button
-            type="button"
-            className="flex cursor-pointer items-center gap-1.5 rounded-lg border-none bg-transparent px-2.5 py-1.5 text-sm text-[var(--text)] transition-colors hover:bg-purple-400/12 hover:text-purple-400"
-            onClick={onBack}
-          >
-            <BackIcon /> Back
-          </button>
-          <Link
-            to="/"
-            className="ml-auto cursor-pointer text-[22px] font-bold tracking-[4px] text-[var(--text-h)] no-underline"
-          >
-            FIER
-          </Link>
-        </div>
-      </header>
-
       <main className="relative z-[1] mx-auto box-border w-full max-w-[1280px] px-6 pt-12 pb-16">
         <div className="mb-10">
           <p className="m-0 mb-2.5 text-[11px] font-bold tracking-[5px] text-purple-400 uppercase">

--- a/frontend/src/pages/home/components/Footer.jsx
+++ b/frontend/src/pages/home/components/Footer.jsx
@@ -1,4 +1,16 @@
+import { useNavigate } from 'react-router-dom'
+
+const SHOP_CATEGORIES = [
+  { label: "Women's Clothing", title: "Women's Clothing", subtitle: 'New arrivals every week', hue: 280 },
+  { label: "Men's Clothing", title: "Men's Clothing", subtitle: 'Timeless essentials', hue: 210 },
+  { label: 'Outerwear', title: 'Outerwear', subtitle: 'Coats, jackets & more', hue: 200 },
+  { label: 'Footwear', title: 'Footwear', subtitle: 'Step into style', hue: 160 },
+  { label: 'Accessories', title: 'Accessories', subtitle: 'Finish the look', hue: 40 },
+  { label: 'Sale', title: 'Sale', subtitle: 'Exclusive discounts on selected items', hue: 0, on_sale: true },
+]
+
 export default function Footer() {
+  const navigate = useNavigate()
   const linkCls =
     'cursor-pointer text-[13px] text-[var(--text)] transition-colors hover:text-purple-400'
 
@@ -31,33 +43,25 @@ export default function Footer() {
         </div>
 
         {/* Links */}
-        <div className="grid flex-1 grid-cols-3 gap-8 max-[420px]:grid-cols-1 max-sm:grid-cols-2">
+        <div className="grid flex-1 grid-cols-2 gap-8 max-[420px]:grid-cols-1">
           {[
             {
               heading: 'Shop',
-              links: [
-                "Women's Clothing",
-                "Men's Clothing",
-                'Outerwear',
-                'Footwear',
-                'Accessories',
-                'Sale',
-              ],
+              links: SHOP_CATEGORIES.map(({ label, ...category }) => ({
+                label,
+                onClick: () => navigate('/category', { state: { category } }),
+              })),
             },
             {
               heading: 'Customer Service',
               links: [
-                'Contact Us',
-                'Track My Order',
-                'Returns & Exchanges',
-                'Shipping Info',
-                'Size Guide',
-                'FAQ',
+                { label: 'Contact Us', onClick: () => navigate('/help') },
+                { label: 'Track My Order', onClick: () => navigate('/orders') },
+                { label: 'Returns & Exchanges', onClick: () => navigate('/help') },
+                { label: 'Shipping Info', onClick: () => navigate('/help') },
+                { label: 'Size Guide', onClick: () => navigate('/help') },
+                { label: 'FAQ', onClick: () => navigate('/help') },
               ],
-            },
-            {
-              heading: 'Company',
-              links: ['About Us', 'Careers', 'Press', 'Sustainability', 'Affiliate Program'],
             },
           ].map(({ heading, links }) => (
             <div key={heading}>
@@ -65,9 +69,9 @@ export default function Footer() {
                 {heading}
               </h4>
               <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
-                {links.map((l) => (
-                  <li key={l} className={linkCls}>
-                    {l}
+                {links.map(({ label, onClick }) => (
+                  <li key={label} className={linkCls} onClick={onClick}>
+                    {label}
                   </li>
                 ))}
               </ul>

--- a/frontend/src/pages/home/components/Footer.jsx
+++ b/frontend/src/pages/home/components/Footer.jsx
@@ -1,12 +1,23 @@
 import { useNavigate } from 'react-router-dom'
 
 const SHOP_CATEGORIES = [
-  { label: "Women's Clothing", title: "Women's Clothing", subtitle: 'New arrivals every week', hue: 280 },
+  {
+    label: "Women's Clothing",
+    title: "Women's Clothing",
+    subtitle: 'New arrivals every week',
+    hue: 280,
+  },
   { label: "Men's Clothing", title: "Men's Clothing", subtitle: 'Timeless essentials', hue: 210 },
   { label: 'Outerwear', title: 'Outerwear', subtitle: 'Coats, jackets & more', hue: 200 },
   { label: 'Footwear', title: 'Footwear', subtitle: 'Step into style', hue: 160 },
   { label: 'Accessories', title: 'Accessories', subtitle: 'Finish the look', hue: 40 },
-  { label: 'Sale', title: 'Sale', subtitle: 'Exclusive discounts on selected items', hue: 0, on_sale: true },
+  {
+    label: 'Sale',
+    title: 'Sale',
+    subtitle: 'Exclusive discounts on selected items',
+    hue: 0,
+    on_sale: true,
+  },
 ]
 
 export default function Footer() {

--- a/frontend/src/pages/home/components/HeroBanner.jsx
+++ b/frontend/src/pages/home/components/HeroBanner.jsx
@@ -27,10 +27,10 @@ export default function HeroBanner() {
   }, [])
 
   return (
-    <section className="light:before:opacity-100 relative isolate z-[1] flex h-svh items-center justify-center overflow-hidden bg-[#100d1e] px-6 pt-[72px] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:z-[2] before:h-40 before:bg-gradient-to-b before:from-white/30 before:to-transparent before:opacity-0 after:pointer-events-none after:absolute after:inset-0 after:[background:radial-gradient(ellipse_at_center,transparent_40%,rgba(0,0,0,0.4)_100%),linear-gradient(to_bottom,transparent_55%,rgba(16,13,30,0.6)_78%,#100d1e_100%)]">
+    <section className="light:before:opacity-100 relative isolate z-[1] flex h-svh items-center justify-center overflow-hidden bg-[#100d1e] light:bg-white px-6 pt-[72px] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:z-[2] before:h-40 before:bg-gradient-to-b before:from-white/30 before:to-transparent before:opacity-0 after:pointer-events-none after:absolute after:inset-0 after:[background:radial-gradient(ellipse_at_center,transparent_40%,rgba(0,0,0,0.4)_100%),linear-gradient(to_bottom,transparent_55%,rgba(16,13,30,0.6)_78%,#100d1e_100%)] light:after:[background:none]">
       {/* Spline 3D background */}
       <div
-        className="pointer-events-none absolute -top-[20%] right-0 bottom-0 left-0 z-[-1] overflow-hidden"
+        className="pointer-events-none absolute -top-[20%] right-0 bottom-0 left-0 z-[-1] overflow-hidden light:[filter:invert(1)_hue-rotate(180deg)]"
         aria-hidden="true"
       >
         {shouldLoad3D ? (
@@ -50,10 +50,10 @@ export default function HeroBanner() {
         <p className="mb-4 text-[11px] font-bold tracking-[5px] text-purple-400 uppercase opacity-90">
           New Season
         </p>
-        <h1 className="m-0 mb-4 text-[clamp(40px,10vw,72px)] leading-[1.05] font-extrabold tracking-[-2px] text-white [text-shadow:0_4px_40px_rgba(0,0,0,0.4)]">
+        <h1 className="m-0 mb-4 text-[clamp(40px,10vw,72px)] leading-[1.05] font-extrabold tracking-[-2px] text-white light:text-gray-900 [text-shadow:0_4px_40px_rgba(0,0,0,0.4)] light:[text-shadow:none]">
           Discover Your Style
         </h1>
-        <p className="mb-9 max-w-[500px] tracking-[0.5px] text-white/55">
+        <p className="mb-9 max-w-[500px] tracking-[0.5px] text-white/55 light:text-gray-500">
           Curated fashion for every occasion
         </p>
         <button

--- a/frontend/src/pages/home/components/HeroBanner.jsx
+++ b/frontend/src/pages/home/components/HeroBanner.jsx
@@ -27,10 +27,10 @@ export default function HeroBanner() {
   }, [])
 
   return (
-    <section className="light:before:opacity-100 relative isolate z-[1] flex h-svh items-center justify-center overflow-hidden bg-[#100d1e] light:bg-white px-6 pt-[72px] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:z-[2] before:h-40 before:bg-gradient-to-b before:from-white/30 before:to-transparent before:opacity-0 after:pointer-events-none after:absolute after:inset-0 after:[background:radial-gradient(ellipse_at_center,transparent_40%,rgba(0,0,0,0.4)_100%),linear-gradient(to_bottom,transparent_55%,rgba(16,13,30,0.6)_78%,#100d1e_100%)] light:after:[background:none]">
+    <section className="light:before:opacity-100 light:bg-white light:after:[background:none] relative isolate z-[1] flex h-svh items-center justify-center overflow-hidden bg-[#100d1e] px-6 pt-[72px] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:z-[2] before:h-40 before:bg-gradient-to-b before:from-white/30 before:to-transparent before:opacity-0 after:pointer-events-none after:absolute after:inset-0 after:[background:radial-gradient(ellipse_at_center,transparent_40%,rgba(0,0,0,0.4)_100%),linear-gradient(to_bottom,transparent_55%,rgba(16,13,30,0.6)_78%,#100d1e_100%)]">
       {/* Spline 3D background */}
       <div
-        className="pointer-events-none absolute -top-[20%] right-0 bottom-0 left-0 z-[-1] overflow-hidden light:[filter:invert(1)_hue-rotate(180deg)]"
+        className="light:[filter:invert(1)_hue-rotate(180deg)] pointer-events-none absolute -top-[20%] right-0 bottom-0 left-0 z-[-1] overflow-hidden"
         aria-hidden="true"
       >
         {shouldLoad3D ? (
@@ -50,10 +50,10 @@ export default function HeroBanner() {
         <p className="mb-4 text-[11px] font-bold tracking-[5px] text-purple-400 uppercase opacity-90">
           New Season
         </p>
-        <h1 className="m-0 mb-4 text-[clamp(40px,10vw,72px)] leading-[1.05] font-extrabold tracking-[-2px] text-white light:text-gray-900 [text-shadow:0_4px_40px_rgba(0,0,0,0.4)] light:[text-shadow:none]">
+        <h1 className="light:text-gray-900 light:[text-shadow:none] m-0 mb-4 text-[clamp(40px,10vw,72px)] leading-[1.05] font-extrabold tracking-[-2px] text-white [text-shadow:0_4px_40px_rgba(0,0,0,0.4)]">
           Discover Your Style
         </h1>
-        <p className="mb-9 max-w-[500px] tracking-[0.5px] text-white/55 light:text-gray-500">
+        <p className="light:text-gray-500 mb-9 max-w-[500px] tracking-[0.5px] text-white/55">
           Curated fashion for every occasion
         </p>
         <button

--- a/frontend/test/CategoryPage.test.jsx
+++ b/frontend/test/CategoryPage.test.jsx
@@ -8,7 +8,6 @@ const category = { title: 'Electronics', subtitle: 'Gadgets and gear' }
 
 const defaultProps = {
   category,
-  onBack: vi.fn(),
   onAddToWishlist: vi.fn(),
   onRemoveFromWishlist: vi.fn(),
   wishlistItems: [],
@@ -168,23 +167,6 @@ describe('CategoryPage', () => {
     await waitForElementToBeRemoved(() => screen.queryByText(/loading products/i))
 
     expect(screen.queryByRole('button', { name: /add to cart/i })).not.toBeInTheDocument()
-  })
-
-  it('calls onBack when Back button is clicked', async () => {
-    const onBack = vi.fn()
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ products: [] }),
-      })
-    )
-
-    renderPage({ onBack })
-
-    await userEvent.click(screen.getByRole('button', { name: /back/i }))
-
-    expect(onBack).toHaveBeenCalledOnce()
   })
 
   it('fetches products using the category title in the URL', async () => {


### PR DESCRIPTION
## Summary

- **Light mode hero**: hero banner now uses a white background in light mode; the Spline 3D wave is preserved via `filter: invert(1) hue-rotate(180deg)`, with text colors adapted for light backgrounds
- **Footer – Shop links**: all six Shop column links navigate to the correct category page; Sale uses a new `?on_sale=true` backend filter to show discounted products; Customer Service links route to `/help` or `/orders`; Company column removed as no backing pages exist
- **Category page navbar**: replaced the category page's one-off custom header with the shared `CustomerLayout` navbar, consistent with every other customer-facing page

## Test plan

- [ ] Toggle light mode — hero section shows white background with wave visible
- [ ] Click each Shop footer link — navigates to the correct category page with products loaded
- [ ] Click Sale footer link — navigates to a page showing only discounted products
- [ ] Click Customer Service links — Contact Us, Returns, Shipping Info, Size Guide, FAQ all open `/help`; Track My Order opens `/orders`
- [ ] Navigate to any category — navbar is the same fixed bar as the rest of the site