### PR TITLE
fix: include shipping cost in invoice and replace order summary with full invoice

### DIFF
--- a/backend/migrations/26_add_shipping_cost_to_orders.js
+++ b/backend/migrations/26_add_shipping_cost_to_orders.js
@@ -1,0 +1,9 @@
+exports.up = (pgm) => {
+  pgm.addColumn('orders', {
+    shipping_cost: { type: 'numeric(10,2)', notNull: true, default: 0 },
+  })
+}
+
+exports.down = (pgm) => {
+  pgm.dropColumn('orders', 'shipping_cost')
+}

--- a/backend/routes/admin-orders.js
+++ b/backend/routes/admin-orders.js
@@ -43,7 +43,7 @@ router.get('/', async (req, res) => {
   const total = parseInt(countResult.rows[0].count)
 
   const dataResult = await pool.query(
-    `SELECT o.id, o.status, o.total, o.address, o.created_at, o.updated_at,
+    `SELECT o.id, o.status, o.total, o.shipping_cost, o.address, o.created_at, o.updated_at,
             u.id AS user_id, u.email AS user_email
      FROM orders o
      JOIN auth.users u ON u.id = o.user_id
@@ -62,7 +62,7 @@ router.get('/', async (req, res) => {
 // GET /api/admin/orders/:id — single order with items
 router.get('/:id', async (req, res) => {
   const orderResult = await pool.query(
-    `SELECT o.id, o.status, o.total, o.address, o.created_at, o.updated_at,
+    `SELECT o.id, o.status, o.total, o.shipping_cost, o.address, o.created_at, o.updated_at,
             u.id AS user_id, u.email AS user_email
      FROM orders o
      JOIN auth.users u ON u.id = o.user_id

--- a/backend/routes/checkout.js
+++ b/backend/routes/checkout.js
@@ -182,9 +182,15 @@ router.post('/confirm', async (req, res) => {
       0
     )
 
+    const thresholdResult = await pool.query(
+      `SELECT value FROM system_settings WHERE key = 'free_shipping_threshold'`
+    )
+    const threshold = parseFloat(thresholdResult.rows[0]?.value ?? '100')
+    const shippingCost = total >= threshold ? 0 : 4.99
+
     const orderResult = await client.query(
-      `INSERT INTO orders (user_id, status, total, address) VALUES ($1, 'pending', $2, $3) RETURNING id`,
-      [userId, total.toFixed(2), address]
+      `INSERT INTO orders (user_id, status, total, address, shipping_cost) VALUES ($1, 'pending', $2, $3, $4) RETURNING id`,
+      [userId, total.toFixed(2), address, shippingCost.toFixed(2)]
     )
     const orderId = orderResult.rows[0].id
 
@@ -200,12 +206,15 @@ router.post('/confirm', async (req, res) => {
 
     await client.query('COMMIT')
 
+    const invoiceNumber = `INV-${new Date().getFullYear()}-${String(orderId).padStart(6, '0')}`
+
     queueInvoiceRequest({
-      invoice_number: `INV-${new Date().getFullYear()}-${String(orderId).padStart(6, '0')}`,
+      invoice_number: invoiceNumber,
       order_id: String(orderId),
       customer_name: inferCustomerName(req.user.email),
       customer_email: req.user.email,
       customer_address: address || 'Address not provided',
+      shipping_cost: shippingCost,
       items: reservations.rows.map((item) => ({
         description: item.name,
         quantity: item.quantity,
@@ -218,7 +227,10 @@ router.post('/confirm', async (req, res) => {
     // stale cart snapshot the client built before any mid-checkout discount.
     res.json({
       order_id: orderId,
+      invoice_number: invoiceNumber,
+      customer_email: req.user.email,
       total: Number(total.toFixed(2)),
+      shipping_cost: shippingCost,
       items: reservations.rows.map((item) => ({
         product_id: item.product_id,
         name: item.name,

--- a/backend/routes/product-manager.js
+++ b/backend/routes/product-manager.js
@@ -330,7 +330,7 @@ router.get('/orders', async (req, res) => {
   const total = parseInt(countResult.rows[0].count)
 
   const dataResult = await pool.query(
-    `SELECT o.id, o.status, o.total, o.address, o.created_at, o.updated_at,
+    `SELECT o.id, o.status, o.total, o.shipping_cost, o.address, o.created_at, o.updated_at,
             u.id AS user_id, u.email AS user_email
      FROM orders o
      JOIN auth.users u ON u.id = o.user_id
@@ -370,7 +370,7 @@ router.patch('/orders/:id/status', async (req, res) => {
 // GET /api/product-manager/orders/:id
 router.get('/orders/:id', async (req, res) => {
   const orderResult = await pool.query(
-    `SELECT o.id, o.status, o.total, o.address, o.created_at, o.updated_at,
+    `SELECT o.id, o.status, o.total, o.shipping_cost, o.address, o.created_at, o.updated_at,
             u.id AS user_id, u.email AS user_email
      FROM orders o
      JOIN auth.users u ON u.id = o.user_id

--- a/backend/services/invoice.js
+++ b/backend/services/invoice.js
@@ -154,8 +154,9 @@ function buildInvoiceData(request, options = {}) {
     }
   })
   const subtotal = roundMoney(items.reduce((sum, item) => sum + item.total, 0))
+  const shipping_cost = roundMoney(request.shipping_cost ?? 0)
   const tax_amount = roundMoney(subtotal * taxRate)
-  const total = roundMoney(subtotal + tax_amount)
+  const total = roundMoney(subtotal + shipping_cost + tax_amount)
 
   return {
     number: request.invoice_number,
@@ -171,6 +172,7 @@ function buildInvoiceData(request, options = {}) {
       year: 'numeric',
     }),
     subtotal,
+    shipping_cost,
     tax_rate: taxRate,
     tax_amount,
     total,
@@ -366,18 +368,28 @@ function generateInvoicePdf(invoice) {
         align: 'right',
       })
 
+    const shippingLabel = invoice.shipping_cost === 0 ? 'Shipping (Free)' : 'Shipping'
     doc
       .fillColor(colors.muted)
-      .text(`Tax (${Math.round(invoice.tax_rate * 100)}%)`, totalsX, y + 40, { width: 80 })
+      .text(shippingLabel, totalsX, y + 40, { width: 80 })
       .fillColor(colors.text)
-      .text(formatMoney(invoice.tax_amount), totalsX + 100, y + 40, {
+      .text(formatMoney(invoice.shipping_cost), totalsX + 100, y + 40, {
         width: 80,
         align: 'right',
       })
 
     doc
-      .moveTo(totalsX, y + 66)
-      .lineTo(totalsX + totalsWidth, y + 66)
+      .fillColor(colors.muted)
+      .text(`Tax (${Math.round(invoice.tax_rate * 100)}%)`, totalsX, y + 60, { width: 80 })
+      .fillColor(colors.text)
+      .text(formatMoney(invoice.tax_amount), totalsX + 100, y + 60, {
+        width: 80,
+        align: 'right',
+      })
+
+    doc
+      .moveTo(totalsX, y + 86)
+      .lineTo(totalsX + totalsWidth, y + 86)
       .strokeColor(colors.primary)
       .lineWidth(2)
       .stroke()
@@ -386,8 +398,8 @@ function generateInvoicePdf(invoice) {
       .font('Helvetica-Bold')
       .fontSize(15)
       .fillColor(colors.primary)
-      .text('Total', totalsX, y + 76, { width: 80 })
-      .text(formatMoney(invoice.total), totalsX + 100, y + 76, { width: 80, align: 'right' })
+      .text('Total', totalsX, y + 96, { width: 80 })
+      .text(formatMoney(invoice.total), totalsX + 100, y + 96, { width: 80, align: 'right' })
 
     doc.moveTo(60, 730).lineTo(535, 730).strokeColor(colors.border).lineWidth(1).stroke()
     doc

--- a/backend/test/checkout.test.js
+++ b/backend/test/checkout.test.js
@@ -276,6 +276,7 @@ describe('POST /api/checkout/confirm', () => {
         },
       ],
     })
+    pool.query.mockResolvedValueOnce({ rows: [{ value: '100' }] }) // free_shipping_threshold
 
     const client = makeClient([
       { rows: [] }, // BEGIN
@@ -314,6 +315,7 @@ describe('POST /api/checkout/confirm', () => {
       customer_name: 'User',
       customer_email: 'user@example.com',
       customer_address: '123 Main St',
+      shipping_cost: 4.99,
       items: [{ description: 'Widget', quantity: 2, unit_price: 9.99 }],
     })
   })
@@ -332,6 +334,7 @@ describe('POST /api/checkout/confirm', () => {
         },
       ],
     })
+    pool.query.mockResolvedValueOnce({ rows: [{ value: '100' }] }) // free_shipping_threshold
 
     const client = makeClient([
       { rows: [] }, // BEGIN
@@ -369,6 +372,7 @@ describe('POST /api/checkout/confirm', () => {
         },
       ],
     })
+    pool.query.mockResolvedValueOnce({ rows: [{ value: '100' }] }) // free_shipping_threshold
 
     const client = makeClient([
       { rows: [] }, // BEGIN

--- a/frontend/src/pages/cart/CartPage.jsx
+++ b/frontend/src/pages/cart/CartPage.jsx
@@ -268,18 +268,18 @@ export default function CartPage({
             </div>
             <div className="flex items-center justify-between text-sm text-[var(--text)]">
               <span>Shipping</span>
-              <span className={total >= 50 ? 'font-semibold text-[#4caf82]' : ''}>
-                {total >= 50 ? 'Free' : '$4.99'}
+              <span className={total >= 100 ? 'font-semibold text-[#4caf82]' : ''}>
+                {total >= 100 ? 'Free' : '$4.99'}
               </span>
             </div>
             <hr className="my-1 border-t border-[var(--border)]" />
             <div className="flex items-center justify-between text-[16px] font-bold text-[var(--text-h)]">
               <span>Total</span>
-              <span>${(total + (total >= 50 ? 0 : 4.99)).toFixed(2)}</span>
+              <span>${(total + (total >= 100 ? 0 : 4.99)).toFixed(2)}</span>
             </div>
-            {total < 50 && (
+            {total < 100 && (
               <p className="-mt-1 text-center text-xs text-purple-400">
-                Add ${(50 - total).toFixed(2)} more for free shipping
+                Add ${(100 - total).toFixed(2)} more for free shipping
               </p>
             )}
             {hasOutOfStock && (

--- a/frontend/src/pages/checkout/CheckoutPage.jsx
+++ b/frontend/src/pages/checkout/CheckoutPage.jsx
@@ -196,7 +196,7 @@ export default function CheckoutPage({
   const effectivePrice = (item) =>
     parseFloat(item.discounted_price != null ? item.discounted_price : item.price)
   const total = cartItems.reduce((sum, item) => sum + effectivePrice(item) * item.quantity, 0)
-  const shippingCost = total >= 50 ? 0 : 4.99
+  const shippingCost = total >= 100 ? 0 : 4.99
   const cardType = getCardType(payment.cardNumber)
   const maskedCard = payment.cardNumber
     ? '•••• •••• •••• ' + payment.cardNumber.replace(/\s/g, '').slice(-4).padStart(4, '•')
@@ -287,12 +287,18 @@ export default function CheckoutPage({
       // landed during checkout.
       const canonicalItems = data.items || cartItems
       const canonicalSubtotal = typeof data.total === 'number' ? data.total : total
-      const finalShipping = canonicalSubtotal >= 50 ? 0 : 4.99
       onOrderConfirmed({
         orderId: data.order_id,
+        invoiceNumber: data.invoice_number,
+        customerEmail: data.customer_email,
         items: canonicalItems,
         subtotal: canonicalSubtotal,
-        shippingCost: finalShipping,
+        shippingCost:
+          typeof data.shipping_cost === 'number'
+            ? data.shipping_cost
+            : canonicalSubtotal >= 100
+              ? 0
+              : 4.99,
         address: addressStr,
       })
     } catch {

--- a/frontend/src/pages/checkout/OrderSuccessPage.jsx
+++ b/frontend/src/pages/checkout/OrderSuccessPage.jsx
@@ -41,8 +41,22 @@ export default function OrderSuccessPage() {
 
   if (!state?.orderId) return <Navigate to="/" replace />
 
-  const { orderId, items = [], subtotal = 0, shippingCost = 0, address = '' } = state
-  const invoiceNumber = `INV-${new Date().getFullYear()}-${String(orderId).padStart(6, '0')}`
+  const {
+    orderId,
+    invoiceNumber: stateInvoiceNumber,
+    customerEmail,
+    items = [],
+    subtotal = 0,
+    shippingCost = 0,
+    address = '',
+  } = state
+  const invoiceNumber =
+    stateInvoiceNumber ?? `INV-${new Date().getFullYear()}-${String(orderId).padStart(6, '0')}`
+  const invoiceDate = new Date().toLocaleDateString('en-US', {
+    month: 'long',
+    day: '2-digit',
+    year: 'numeric',
+  })
   const grandTotal = subtotal + shippingCost
 
   const effectivePrice = (item) =>
@@ -90,11 +104,26 @@ export default function OrderSuccessPage() {
 
         {/* Invoice card */}
         <div className="rounded-2xl border border-[var(--glass-border)] bg-[var(--card-bg)] shadow-[var(--shadow)] backdrop-blur-xl">
+          {/* Invoice header */}
+          <div className="flex items-start justify-between border-b border-[var(--border)] p-6 pb-4">
+            <div>
+              <h2 className="m-0 text-[14px] font-bold tracking-[0.8px] text-[var(--text)] uppercase opacity-60">
+                Invoice
+              </h2>
+              <p className="m-0 mt-1 text-[12px] text-[var(--text)] opacity-50">{invoiceNumber}</p>
+            </div>
+            <div className="text-right">
+              <p className="m-0 text-[12px] text-[var(--text)] opacity-50">{invoiceDate}</p>
+              {customerEmail && (
+                <p className="m-0 mt-0.5 text-[12px] text-[var(--text)] opacity-50">
+                  {customerEmail}
+                </p>
+              )}
+            </div>
+          </div>
+
           {/* Items */}
           <div className="p-6 pb-4">
-            <h2 className="m-0 mb-4 text-[14px] font-bold tracking-[0.8px] text-[var(--text)] uppercase opacity-60">
-              Order Summary
-            </h2>
             <div className="flex flex-col gap-3">
               {items.map((item) => {
                 const lineTotal = effectivePrice(item) * item.quantity
@@ -138,6 +167,10 @@ export default function OrderSuccessPage() {
               <span className={shippingCost === 0 ? 'font-semibold text-[#4caf82]' : ''}>
                 {shippingCost === 0 ? 'Free' : `$${shippingCost.toFixed(2)}`}
               </span>
+            </div>
+            <div className="flex justify-between text-sm text-[var(--text)] opacity-60">
+              <span>Tax (0%)</span>
+              <span>$0.00</span>
             </div>
             <div className="flex justify-between text-[15px] font-bold text-[var(--text-h)]">
               <span>Total Paid</span>

--- a/frontend/test/CartPage.test.jsx
+++ b/frontend/test/CartPage.test.jsx
@@ -166,8 +166,8 @@ describe('CartPage', () => {
     expect(screen.getByText('$44.97')).toBeInTheDocument()
   })
 
-  it('shows free shipping when total is $50 or more', () => {
-    const expensiveItem = { id: 2, name: 'Expensive', price: '30.00', quantity: 2 }
+  it('shows free shipping when total is $100 or more', () => {
+    const expensiveItem = { id: 2, name: 'Expensive', price: '55.00', quantity: 2 }
     renderPage({ cartItems: [expensiveItem] })
 
     expect(screen.getByText('Free')).toBeInTheDocument()


### PR DESCRIPTION
Closes #103
Closes #105

## Summary
- Include shipping cost in the PDF invoice total (and audit all other views where order totals are rendered for the same omission).
- Replace the post-checkout order summary section with a full inline invoice that mirrors the PDF invoice content while keeping the current page aesthetic.